### PR TITLE
feat: add Twitter/X auto-download support via yt-dlp

### DIFF
--- a/src/instagram_video_bot/__main__.py
+++ b/src/instagram_video_bot/__main__.py
@@ -31,13 +31,9 @@ def check_environment() -> None:
     if not getattr(settings, "BOT_TOKEN"):
         missing_vars.append("BOT_TOKEN")
     
-    # Check if accounts.txt exists for multi-account mode
-    accounts_file_path = "/app/accounts.txt"
-    if not os.path.exists(accounts_file_path):
-        # Single account mode - require IG_USERNAME and IG_PASSWORD
-        for var in ["IG_USERNAME", "IG_PASSWORD"]:
-            if not getattr(settings, var):
-                missing_vars.append(var)
+    # Instagram credentials are optional at startup.
+    # This allows Twitter/X-only operation without IG_USERNAME/IG_PASSWORD.
+    # Instagram downloads will still fail at request time if credentials are absent.
 
     if missing_vars:
         raise ValueError(

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -22,11 +22,14 @@ from .video_downloader import VideoDownloadError, VideoDownloader, VideoInfo
 logger = logging.getLogger(__name__)
 
 class TelegramBot:
-    """Telegram bot for downloading Instagram videos."""
+    """Telegram bot for downloading media links."""
 
-    # Instagram URL pattern (supports posts, reels, tv, stories, share links, and ddinstagram aliases)
+    # Supported URL pattern (Instagram routes + Twitter/X status links)
     INSTAGRAM_VIDEO_PATTERN = re.compile(
-        r"(https?://(?:www\.|d\.|g\.)?(?:instagram\.com|ddinstagram\.com)/[^ ]+)"
+        r"("
+        r"https?://(?:www\.|d\.|g\.)?(?:instagram\.com|ddinstagram\.com)/[^ ]+"
+        r"|https?://(?:www\.)?(?:twitter\.com|x\.com)/[^ ]+"
+        r")"
     )
 
     def __init__(self):
@@ -36,7 +39,7 @@ class TelegramBot:
 
     async def handle_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """
-        Handle incoming messages and process Instagram video links.
+        Handle incoming messages and process supported media links.
         
         Args:
             update: Telegram update object
@@ -52,7 +55,7 @@ class TelegramBot:
             return
 
         url = match.group(1)
-        logger.info(f"Processing Instagram URL: {url}")
+        logger.info(f"Processing media URL: {url}")
 
         status_message: Optional[Message] = None
         downloaded_files: List[Path] = []

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -28,7 +28,7 @@ class TelegramBot:
     INSTAGRAM_VIDEO_PATTERN = re.compile(
         r"("
         r"https?://(?:www\.|d\.|g\.)?(?:instagram\.com|ddinstagram\.com)/[^ ]+"
-        r"|https?://(?:www\.)?(?:twitter\.com|x\.com)/[^ ]+"
+        r"|https?://(?:www\.)?(?:twitter\.com|x\.com)/[^/\s]+/status/\d+(?:[/?#][^\s]*)?"
         r")"
     )
 

--- a/src/instagram_video_bot/services/twitter_downloader.py
+++ b/src/instagram_video_bot/services/twitter_downloader.py
@@ -91,7 +91,12 @@ class TwitterDownloader:
         if self.proxy:
             cmd.extend(["--proxy", self.proxy])
 
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout_seconds)
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            raise TwitterDownloadError(
+                f"Twitter/X download timed out after {self.timeout_seconds} seconds"
+            ) from exc
         if result.returncode != 0:
             error_text = (result.stderr or result.stdout or "Unknown yt-dlp error").strip()
             raise TwitterDownloadError(f"Twitter/X download failed: {error_text}")

--- a/src/instagram_video_bot/services/twitter_downloader.py
+++ b/src/instagram_video_bot/services/twitter_downloader.py
@@ -1,0 +1,141 @@
+"""Twitter/X media downloader powered by yt-dlp."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Literal, Sequence
+
+
+class TwitterDownloadError(Exception):
+    """Raised when Twitter/X media extraction fails."""
+
+
+@dataclass
+class TwitterMediaItem:
+    """Downloaded media item from a tweet."""
+
+    file_path: Path
+    media_type: Literal["video", "photo"]
+
+
+@dataclass
+class TwitterDownloadResult:
+    """Successful Twitter/X download output."""
+
+    title: str
+    media_items: List[TwitterMediaItem]
+
+
+class TwitterDownloader:
+    """Downloads public Twitter/X tweet media with yt-dlp."""
+
+    STATUS_URL_PATTERN = re.compile(
+        r"https?://(?:www\.)?(?:twitter\.com|x\.com)/[^/\s]+/status/(?P<status_id>\d+)(?:[/?#][^\s]*)?",
+        re.IGNORECASE,
+    )
+
+    def __init__(self, timeout_seconds: int = 90, proxy: str | None = None, ytdlp_binary: str = "yt-dlp"):
+        self.timeout_seconds = timeout_seconds
+        self.proxy = proxy
+        self.ytdlp_binary = ytdlp_binary
+
+    @classmethod
+    def is_supported_url(cls, url: str) -> bool:
+        """Return whether URL is a supported Twitter/X status link."""
+        return bool(cls.STATUS_URL_PATTERN.search(url.strip()))
+
+    async def download_media(self, url: str, output_dir: Path) -> TwitterDownloadResult:
+        """Download all available media for a public tweet."""
+        if not self.is_supported_url(url):
+            raise TwitterDownloadError("Unsupported Twitter/X URL")
+        return await asyncio.to_thread(self._download_media_sync, url, output_dir)
+
+    def _download_media_sync(self, url: str, output_dir: Path) -> TwitterDownloadResult:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        status_id = self._extract_status_id(url)
+        prefix = f"twitter_{status_id}_{int(time.time() * 1000)}"
+        output_template = str(output_dir / f"{prefix}_%(autonumber)02d.%(ext)s")
+
+        cmd = self._build_base_command()
+        cmd.extend(
+            [
+                "--no-warnings",
+                "--no-progress",
+                "--restrict-filenames",
+                "--no-part",
+                "-o",
+                output_template,
+                url,
+            ]
+        )
+        if self.proxy:
+            cmd.extend(["--proxy", self.proxy])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout_seconds)
+        if result.returncode != 0:
+            error_text = (result.stderr or result.stdout or "Unknown yt-dlp error").strip()
+            raise TwitterDownloadError(f"Twitter/X download failed: {error_text}")
+
+        file_paths = self._collect_files(output_dir, prefix)
+        if not file_paths:
+            raise TwitterDownloadError("Twitter/X download produced no media files")
+
+        media_items = [
+            TwitterMediaItem(file_path=path, media_type=self._infer_media_type(path))
+            for path in file_paths
+        ]
+        return TwitterDownloadResult(title=self._fetch_title(url), media_items=media_items)
+
+    def _build_base_command(self) -> List[str]:
+        """Resolve yt-dlp CLI invocation."""
+        if shutil.which(self.ytdlp_binary):
+            return [self.ytdlp_binary]
+        if importlib.util.find_spec("yt_dlp"):
+            return [sys.executable, "-m", "yt_dlp"]
+        raise TwitterDownloadError("yt-dlp is not installed in this environment")
+
+    def _fetch_title(self, url: str) -> str:
+        """Best-effort tweet title extraction for Telegram caption."""
+        cmd = self._build_base_command()
+        cmd.extend(["--no-warnings", "--skip-download", "--print", "%(title)s", url])
+        if self.proxy:
+            cmd.extend(["--proxy", self.proxy])
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=self.timeout_seconds)
+        if result.returncode != 0:
+            return ""
+        title = (result.stdout or "").strip().splitlines()
+        return title[0].strip() if title else ""
+
+    @classmethod
+    def _extract_status_id(cls, url: str) -> str:
+        match = cls.STATUS_URL_PATTERN.search(url.strip())
+        if not match:
+            return "unknown"
+        return match.group("status_id")
+
+    @staticmethod
+    def _collect_files(output_dir: Path, prefix: str) -> Sequence[Path]:
+        files = [
+            file_path
+            for file_path in sorted(output_dir.glob(f"{prefix}_*"))
+            if file_path.is_file()
+            and file_path.suffix.lower() not in {".part", ".ytdl"}
+            and file_path.stat().st_size > 0
+        ]
+        return files
+
+    @staticmethod
+    def _infer_media_type(file_path: Path) -> Literal["video", "photo"]:
+        ext = file_path.suffix.lower()
+        if ext in {".mp4", ".mov", ".mkv", ".webm"}:
+            return "video"
+        return "photo"

--- a/src/instagram_video_bot/services/twitter_downloader.py
+++ b/src/instagram_video_bot/services/twitter_downloader.py
@@ -37,6 +37,18 @@ class TwitterDownloadResult:
 class TwitterDownloader:
     """Downloads public Twitter/X tweet media with yt-dlp."""
 
+    MEDIA_EXTENSIONS = {
+        ".mp4",
+        ".mov",
+        ".mkv",
+        ".webm",
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".webp",
+        ".gif",
+    }
+
     STATUS_URL_PATTERN = re.compile(
         r"https?://(?:www\.)?(?:twitter\.com|x\.com)/[^/\s]+/status/(?P<status_id>\d+)(?:[/?#][^\s]*)?",
         re.IGNORECASE,
@@ -129,6 +141,7 @@ class TwitterDownloader:
             for file_path in sorted(output_dir.glob(f"{prefix}_*"))
             if file_path.is_file()
             and file_path.suffix.lower() not in {".part", ".ytdl"}
+            and file_path.suffix.lower() in TwitterDownloader.MEDIA_EXTENSIONS
             and file_path.stat().st_size > 0
         ]
         return files

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -9,6 +9,7 @@ from typing import List, Literal, Optional
 
 from .instagram_client import InstagramAuthError, InstagramClient
 from .instagram_fast_extractor import InstagramFastExtractor, InstagramFastExtractorError
+from .twitter_downloader import TwitterDownloadError, TwitterDownloader
 from ..config.settings import settings
 from ..utils.account_manager import get_account_manager
 
@@ -68,6 +69,7 @@ class VideoDownloader:
             timeout_connect=settings.IG_FAST_TIMEOUT_CONNECT,
             timeout_read=settings.IG_FAST_TIMEOUT_READ,
         )
+        self.twitter_downloader = TwitterDownloader(proxy=settings.get_single_proxy())
 
     @staticmethod
     def _redact_proxy(proxy: str) -> str:
@@ -110,7 +112,7 @@ class VideoDownloader:
         return self.client
 
     async def download_video(self, url: str, output_dir: Path) -> VideoInfo:
-        """Download a video from Instagram using instagrapi."""
+        """Download media from supported providers."""
         # Rate limiting
         current_time = time.time()
         time_since_last = current_time - self.last_download_time
@@ -124,6 +126,11 @@ class VideoDownloader:
             jitter = random.uniform(*self.random_delay_range)
             logger.debug(f"Adding jitter delay: {jitter:.1f} seconds")
             await asyncio.sleep(jitter)
+
+        if self._is_twitter_url(url):
+            twitter_info = await self._download_twitter_media(url, output_dir)
+            self.last_download_time = time.time()
+            return twitter_info
 
         fast_error: Optional[Exception] = None
         is_story_url = self._is_story_url(url)
@@ -252,6 +259,33 @@ class VideoDownloader:
             raise DownloadError(f"Download failed: fast_path_error={str(fast_error)}")
         raise DownloadError("Download failed")
 
+    async def _download_twitter_media(self, url: str, output_dir: Path) -> VideoInfo:
+        """Download Twitter/X media using yt-dlp."""
+        try:
+            result = await self.twitter_downloader.download_media(url, output_dir)
+        except TwitterDownloadError as error:
+            raise DownloadError(str(error)) from error
+
+        if not result.media_items:
+            raise DownloadError("Twitter/X download returned no media items")
+
+        media_items = [
+            MediaItem(
+                file_path=item.file_path,
+                media_type=item.media_type,
+                caption=result.title or None,
+            )
+            for item in result.media_items
+        ]
+        primary_item = media_items[0]
+        return VideoInfo(
+            file_path=primary_item.file_path,
+            title=result.title or "",
+            description=result.title or "",
+            media_items=media_items,
+            primary_media_type=primary_item.media_type,
+        )
+
     async def _handle_auth_error(self) -> None:
         """Handle authentication errors by trying account rotation."""
         self.client = None  # Reset client
@@ -325,6 +359,11 @@ class VideoDownloader:
     def _is_story_url(url: str) -> bool:
         """Check if URL targets Instagram stories."""
         return "/stories/" in url.lower()
+
+    @staticmethod
+    def _is_twitter_url(url: str) -> bool:
+        """Check if URL targets Twitter/X status routes."""
+        return TwitterDownloader.is_supported_url(url)
 
     @staticmethod
     def _get_fast_proxy() -> Optional[str]:

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Literal, Optional
+from urllib.parse import urlparse
 
 from .instagram_client import InstagramAuthError, InstagramClient
 from .instagram_fast_extractor import InstagramFastExtractor, InstagramFastExtractorError
@@ -131,6 +132,8 @@ class VideoDownloader:
             twitter_info = await self._download_twitter_media(url, output_dir)
             self.last_download_time = time.time()
             return twitter_info
+        if self._is_twitter_domain_url(url):
+            raise DownloadError("Unsupported Twitter/X URL")
 
         fast_error: Optional[Exception] = None
         is_story_url = self._is_story_url(url)
@@ -364,6 +367,16 @@ class VideoDownloader:
     def _is_twitter_url(url: str) -> bool:
         """Check if URL targets Twitter/X status routes."""
         return TwitterDownloader.is_supported_url(url)
+
+    @staticmethod
+    def _is_twitter_domain_url(url: str) -> bool:
+        """Check if URL points to any Twitter/X host, regardless of path."""
+        try:
+            parsed = urlparse(url.strip())
+        except Exception:
+            return False
+        host = (parsed.hostname or "").lower()
+        return host in {"twitter.com", "www.twitter.com", "x.com", "www.x.com"}
 
     @staticmethod
     def _get_fast_proxy() -> Optional[str]:

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -114,10 +114,17 @@ class VideoDownloader:
 
     async def download_video(self, url: str, output_dir: Path) -> VideoInfo:
         """Download media from supported providers."""
+        if self._is_twitter_url(url):
+            twitter_info = await self._download_twitter_media(url, output_dir)
+            self.last_download_time = time.time()
+            return twitter_info
+        if self._is_twitter_domain_url(url):
+            raise DownloadError("Unsupported Twitter/X URL")
+
         # Rate limiting
         current_time = time.time()
         time_since_last = current_time - self.last_download_time
-        
+
         if time_since_last < self.min_delay_between_downloads:
             delay = self.min_delay_between_downloads - time_since_last
             logger.info(f"Rate limiting: waiting {delay:.1f} seconds")
@@ -127,13 +134,6 @@ class VideoDownloader:
             jitter = random.uniform(*self.random_delay_range)
             logger.debug(f"Adding jitter delay: {jitter:.1f} seconds")
             await asyncio.sleep(jitter)
-
-        if self._is_twitter_url(url):
-            twitter_info = await self._download_twitter_media(url, output_dir)
-            self.last_download_time = time.time()
-            return twitter_info
-        if self._is_twitter_domain_url(url):
-            raise DownloadError("Unsupported Twitter/X URL")
 
         fast_error: Optional[Exception] = None
         is_story_url = self._is_story_url(url)
@@ -376,7 +376,14 @@ class VideoDownloader:
         except Exception:
             return False
         host = (parsed.hostname or "").lower()
-        return host in {"twitter.com", "www.twitter.com", "x.com", "www.x.com"}
+        return host in {
+            "twitter.com",
+            "www.twitter.com",
+            "m.twitter.com",
+            "mobile.twitter.com",
+            "x.com",
+            "www.x.com",
+        }
 
     @staticmethod
     def _get_fast_proxy() -> Optional[str]:

--- a/tests/test_main_environment.py
+++ b/tests/test_main_environment.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.instagram_video_bot import __main__ as main_module
+
+
+def test_check_environment_requires_bot_token(monkeypatch):
+    monkeypatch.setattr(main_module.settings, "BOT_TOKEN", "", raising=False)
+    monkeypatch.setattr(main_module.os.path, "exists", lambda _path: False)
+
+    with pytest.raises(ValueError, match="BOT_TOKEN"):
+        main_module.check_environment()
+
+
+def test_check_environment_allows_missing_instagram_credentials(monkeypatch):
+    monkeypatch.setattr(main_module.settings, "BOT_TOKEN", "test-bot-token", raising=False)
+    monkeypatch.setattr(main_module.settings, "IG_USERNAME", "", raising=False)
+    monkeypatch.setattr(main_module.settings, "IG_PASSWORD", "", raising=False)
+    monkeypatch.setattr(main_module.os.path, "exists", lambda _path: False)
+
+    main_module.check_environment()

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -186,3 +186,15 @@ def test_instagram_url_pattern_accepts_expanded_routes(url):
 )
 def test_instagram_url_pattern_accepts_twitter_routes(url):
     assert TelegramBot.INSTAGRAM_VIDEO_PATTERN.search(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://x.com/home",
+        "https://twitter.com/explore",
+        "https://x.com/someuser",
+    ],
+)
+def test_instagram_url_pattern_rejects_non_status_twitter_routes(url):
+    assert TelegramBot.INSTAGRAM_VIDEO_PATTERN.search(url) is None

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -174,3 +174,15 @@ async def test_handle_message_cleans_up_temp_files(tmp_path):
 )
 def test_instagram_url_pattern_accepts_expanded_routes(url):
     assert TelegramBot.INSTAGRAM_VIDEO_PATTERN.search(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://twitter.com/someuser/status/1901234567890123456",
+        "https://x.com/someuser/status/1901234567890123456",
+        "https://www.x.com/someuser/status/1901234567890123456",
+    ],
+)
+def test_instagram_url_pattern_accepts_twitter_routes(url):
+    assert TelegramBot.INSTAGRAM_VIDEO_PATTERN.search(url)

--- a/tests/test_twitter_downloader.py
+++ b/tests/test_twitter_downloader.py
@@ -25,3 +25,15 @@ def test_twitter_downloader_supports_status_urls(url):
 )
 def test_twitter_downloader_rejects_non_status_urls(url):
     assert not TwitterDownloader.is_supported_url(url)
+
+
+def test_collect_files_filters_non_media_sidecars(tmp_path):
+    prefix = "twitter_1900000000000000000_1234567890"
+    (tmp_path / f"{prefix}_01.mp4").write_bytes(b"video")
+    (tmp_path / f"{prefix}_02.jpg").write_bytes(b"photo")
+    (tmp_path / f"{prefix}_03.info.json").write_text("{}")
+    (tmp_path / f"{prefix}_04.vtt").write_text("subtitle")
+
+    files = TwitterDownloader._collect_files(tmp_path, prefix)
+
+    assert [path.suffix for path in files] == [".mp4", ".jpg"]

--- a/tests/test_twitter_downloader.py
+++ b/tests/test_twitter_downloader.py
@@ -1,6 +1,12 @@
+import subprocess
+
 import pytest
 
-from src.instagram_video_bot.services.twitter_downloader import TwitterDownloader
+from src.instagram_video_bot.services import twitter_downloader
+from src.instagram_video_bot.services.twitter_downloader import (
+    TwitterDownloadError,
+    TwitterDownloader,
+)
 
 
 @pytest.mark.parametrize(
@@ -37,3 +43,19 @@ def test_collect_files_filters_non_media_sidecars(tmp_path):
     files = TwitterDownloader._collect_files(tmp_path, prefix)
 
     assert [path.suffix for path in files] == [".mp4", ".jpg"]
+
+
+def test_download_media_converts_download_timeout_to_twitter_error(tmp_path, monkeypatch):
+    downloader = TwitterDownloader(timeout_seconds=5)
+    monkeypatch.setattr(downloader, "_build_base_command", lambda: ["yt-dlp"])
+
+    def _raise_timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="yt-dlp", timeout=5)
+
+    monkeypatch.setattr(twitter_downloader.subprocess, "run", _raise_timeout)
+
+    with pytest.raises(TwitterDownloadError, match="timed out"):
+        downloader._download_media_sync(
+            "https://twitter.com/user/status/1901234567890123456",
+            tmp_path,
+        )

--- a/tests/test_twitter_downloader.py
+++ b/tests/test_twitter_downloader.py
@@ -1,0 +1,27 @@
+import pytest
+
+from src.instagram_video_bot.services.twitter_downloader import TwitterDownloader
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://twitter.com/user/status/1901234567890123456",
+        "https://x.com/user/status/1901234567890123456",
+        "https://www.x.com/user/status/1901234567890123456?s=20",
+    ],
+)
+def test_twitter_downloader_supports_status_urls(url):
+    assert TwitterDownloader.is_supported_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://twitter.com/user",
+        "https://x.com/home",
+        "https://www.instagram.com/reel/abc123/",
+    ],
+)
+def test_twitter_downloader_rejects_non_status_urls(url):
+    assert not TwitterDownloader.is_supported_url(url)

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import time
 
 import pytest
 
@@ -190,6 +191,43 @@ async def test_download_fails_after_retry_on_auth_failure(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_twitter_status_url_skips_instagram_sleep(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 10
+    downloader.random_delay_range = (1, 1)
+    downloader.last_download_time = time.time()
+
+    expected_path = tmp_path / "tweet.mp4"
+    expected_path.write_bytes(b"video")
+    called = {"url": None, "sleep_calls": 0}
+
+    async def _sleep(_seconds):
+        called["sleep_calls"] += 1
+        raise AssertionError("instagram sleep should not run for twitter URLs")
+
+    class _TwitterDownloaderStub:
+        async def download_media(self, url: str, _output_dir: Path) -> VideoInfo:
+            called["url"] = url
+            return VideoInfo(
+                file_path=expected_path,
+                title="tweet",
+                media_items=[MediaItem(file_path=expected_path, media_type="video")],
+                primary_media_type="video",
+            )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.asyncio.sleep", _sleep)
+    downloader.twitter_downloader = _TwitterDownloaderStub()
+    downloader._get_client = lambda: (_ for _ in ()).throw(AssertionError("instagram path should not run"))
+
+    info = await downloader.download_video("https://x.com/someuser/status/1901234567890123456", tmp_path)
+
+    assert called["url"] == "https://x.com/someuser/status/1901234567890123456"
+    assert called["sleep_calls"] == 0
+    assert info.file_path == expected_path
+    assert info.primary_media_type == "video"
+
+
+@pytest.mark.asyncio
 async def test_twitter_url_routes_to_twitter_downloader(tmp_path):
     downloader = VideoDownloader()
     downloader.min_delay_between_downloads = 0
@@ -217,6 +255,17 @@ async def test_twitter_url_routes_to_twitter_downloader(tmp_path):
     assert called["url"] == "https://x.com/someuser/status/1901234567890123456"
     assert info.file_path == expected_path
     assert info.primary_media_type == "video"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://m.twitter.com/someuser/status/1901234567890123456",
+        "https://mobile.twitter.com/someuser/status/1901234567890123456",
+    ],
+)
+def test_is_twitter_domain_url_recognizes_mobile_hosts(url):
+    assert VideoDownloader._is_twitter_domain_url(url)
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -8,7 +8,12 @@ from src.instagram_video_bot.services.instagram_fast_extractor import (
     FastExtractorDownloadResult,
     InstagramFastExtractorError,
 )
-from src.instagram_video_bot.services.video_downloader import DownloadError, VideoDownloader
+from src.instagram_video_bot.services.video_downloader import (
+    DownloadError,
+    MediaItem,
+    VideoDownloader,
+    VideoInfo,
+)
 
 
 class _SuccessDownloadClient:
@@ -182,3 +187,33 @@ async def test_download_fails_after_retry_on_auth_failure(monkeypatch, tmp_path)
 
     with pytest.raises(DownloadError, match="Authentication failed after account rotation retry"):
         await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_twitter_url_routes_to_twitter_downloader(tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+
+    expected_path = tmp_path / "tweet.mp4"
+    expected_path.write_bytes(b"video")
+    called = {"url": None}
+
+    class _TwitterDownloaderStub:
+        async def download_media(self, url: str, _output_dir: Path) -> VideoInfo:
+            called["url"] = url
+            return VideoInfo(
+                file_path=expected_path,
+                title="tweet",
+                media_items=[MediaItem(file_path=expected_path, media_type="video")],
+                primary_media_type="video",
+            )
+
+    downloader.twitter_downloader = _TwitterDownloaderStub()
+    downloader._get_client = lambda: (_ for _ in ()).throw(AssertionError("instagram path should not run"))
+
+    info = await downloader.download_video("https://x.com/someuser/status/1901234567890123456", tmp_path)
+
+    assert called["url"] == "https://x.com/someuser/status/1901234567890123456"
+    assert info.file_path == expected_path
+    assert info.primary_media_type == "video"

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -217,3 +217,16 @@ async def test_twitter_url_routes_to_twitter_downloader(tmp_path):
     assert called["url"] == "https://x.com/someuser/status/1901234567890123456"
     assert info.file_path == expected_path
     assert info.primary_media_type == "video"
+
+
+@pytest.mark.asyncio
+async def test_non_status_twitter_url_fails_without_instagram_fallback(tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    downloader._get_client = lambda: (_ for _ in ()).throw(
+        AssertionError("instagram path should not run")
+    )
+
+    with pytest.raises(DownloadError, match="Unsupported Twitter/X URL"):
+        await downloader.download_video("https://x.com/home", tmp_path)


### PR DESCRIPTION
## Summary
- add a dedicated Twitter/X downloader module powered by `yt-dlp`
- route Twitter/X status links through the new provider while keeping Instagram flow intact
- tighten Twitter URL handling (status-only), reject unsupported Twitter URLs, and allow Twitter-only startup without IG credentials
- add tests for Twitter URL matching, downloader routing, sidecar filtering, and startup environment checks

## Test Plan
- [x] `PYTHONPATH=. pytest -q`
- [x] verified targeted regression tests for non-status Twitter links and media sidecar filtering