### PR TITLE
Fix group chat status noise and shared delivery duplication

### DIFF
--- a/docs/superpowers/specs/2026-04-23-status-noise-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-23-status-noise-cleanup-design.md
@@ -1,0 +1,196 @@
+# Status Noise Cleanup Design
+
+Date: 2026-04-23
+Repo: `/Users/ozaytsev/Softs/Inst_video_downloader_tg_bot`
+Status: Approved for planning, pending implementation approval on written spec
+
+## Summary
+
+Perform a narrow UX cleanup pass for Telegram chat noise after the group-first bot rollout.
+
+Primary goals:
+
+- remove unnecessary success-path bot messages
+- eliminate duplicate or doubled request-status messages
+- keep failures and cancellations visible
+- review nearby request-lifecycle behavior for similar low-value chat noise
+- implement and review the cleanup in a dedicated worktree using subagents for bounded UX-focused analysis
+
+## Goals
+
+- Delete transient status messages on successful completion.
+- Prevent normal success and cache-hit flows from producing duplicate chat messages.
+- Keep request-lifecycle feedback understandable without being noisy.
+- Use a dedicated worktree so the cleanup remains isolated from the deployed checkout.
+- Use subagents only for bounded review slices directly related to this cleanup.
+
+## Non-Goals
+
+- No new provider support.
+- No downloader/infra redesign unless a direct cause of duplicate status behavior is found.
+- No broad architecture rewrite of the Telegram bot.
+- No unrelated command or admin UX polish outside this narrow request-lifecycle scope.
+
+## User-Facing Behavior
+
+### Success Path
+
+On successful media delivery:
+
+- the transient status message should be deleted
+- the user should see the delivered media as the primary outcome
+- no extra `Done` or `Done (cache hit)` success message should remain in chat
+
+### Cache Hit Success
+
+On successful cache-hit delivery:
+
+- the transient status message should also be deleted
+- cache-hit handling should remain quieter than or equal to the normal success path
+- users should not receive extra celebratory or informational success chatter just because the result came from cache
+
+### Failure Path
+
+On failure:
+
+- a useful visible error message should remain
+- the bot must not silently delete all request feedback
+- provider-specific or actionable wording should be preserved where it already exists
+
+### Cancellation Path
+
+On cancellation:
+
+- a visible cancellation status may remain
+- the message should be concise and unambiguous
+
+## Known Problem Class
+
+The current request lifecycle has multiple opportunities for chat-noise duplication:
+
+- initial status creation through `reply_text`
+- later status edits
+- fallback behavior that may reply instead of edit if Telegram rejects an edit
+- cache-hit completion messages that add success text even though the media itself already signals completion
+
+The cleanup should specifically target these normal-path duplications without weakening failure visibility.
+
+## Scope Of Review
+
+### In Scope
+
+- request status message creation, updates, and deletion
+- edit-versus-reply fallback behavior
+- cache-hit success-path UX
+- coalesced/shared-job watcher UX where one underlying job serves multiple requesters
+- obvious low-value command reply noise directly adjacent to this flow
+
+### Out Of Scope
+
+- provider extraction logic that does not affect chat noise
+- account leasing changes unless they directly affect duplicate messaging
+- VPS deployment mechanics
+- admin features unrelated to request lifecycle noise
+
+## Dedicated Worktree
+
+Implementation must happen in a fresh dedicated worktree created from current `main`.
+
+Reasons:
+
+- keep the cleanup isolated from the already-deployed checkout
+- allow safe review and experimentation without mutating the working deployment path
+- make it easier to run bounded subagent work against a stable branch base
+
+## Subagent Plan
+
+Subagents are authorized because the user explicitly asked for a careful review with subagents.
+
+### Subagent 1: Telegram Request Lifecycle
+
+Focus:
+
+- transient status creation
+- edit fallback behavior
+- delete-on-success flow
+- duplicated visible messages in normal success path
+
+Expected output:
+
+- concrete findings about why duplicate messages happen
+- recommended minimal behavioral fixes
+
+### Subagent 2: Cache And Coalescing UX
+
+Focus:
+
+- cache-hit request behavior
+- shared-job watcher behavior
+- duplicate suppression outcomes
+- whether attached requesters receive redundant updates or low-value noise
+
+Expected output:
+
+- findings about cache/coalesced flow noise
+- recommended minimal cleanup changes
+
+### Optional Subagent 3: Command Noise
+
+Use only if needed.
+
+Focus:
+
+- nearby command confirmation chatter
+- whether `/cancel` or related request-facing command flows add avoidable noise
+
+Expected output:
+
+- only direct, scoped findings relevant to this cleanup
+
+## Implementation Strategy
+
+1. Create the dedicated worktree from current `main`.
+2. Run the bounded subagent reviews.
+3. Inspect their findings and confirm the minimal patch set.
+4. Implement the cleanup in the worktree.
+5. Add or update tests for success, cache-hit, failure, and cancellation paths.
+6. Run the relevant tests plus the full suite before publish.
+
+## Expected Code Changes
+
+Likely touch points:
+
+- `src/instagram_video_bot/services/telegram_bot.py`
+- tests covering Telegram request lifecycle and cache-hit behavior
+
+Potentially touched only if directly necessary:
+
+- `job_manager.py`
+- `state_store.py`
+
+## Validation
+
+### Required Tests
+
+- success deletes transient status message
+- cache-hit success deletes transient status message
+- failure leaves useful user-visible error feedback
+- cancellation leaves concise user-visible cancellation feedback
+- normal happy path does not produce doubled request-status messages
+
+### Manual Verification Intent
+
+If practical after implementation:
+
+- simulate cache-hit success
+- simulate non-cache success
+- simulate failure
+- confirm the visible chat transcript is quieter and still understandable
+
+## Success Criteria
+
+- The user no longer sees `Done`-style success messages after media delivery.
+- Cache hits do not create extra visible completion chatter.
+- The normal request lifecycle does not produce doubled messages in chat.
+- Failures and cancellations remain visible and understandable.
+- The cleanup stays narrow, localized, and easy to validate.

--- a/src/instagram_video_bot/services/job_manager.py
+++ b/src/instagram_video_bot/services/job_manager.py
@@ -45,8 +45,11 @@ class SharedJob:
     created_monotonic: float = field(default_factory=monotonic)
     requesters: dict[str, RequestRecord] = field(default_factory=dict)
     result_future: asyncio.Future[Any] | None = None
+    delivery_future: asyncio.Future[bool] | None = None
     task: asyncio.Task[Any] | None = None
     queue_position_at_submit: int = 1
+    delivery_request_id: str | None = None
+    last_delivery_error: Exception | None = None
 
 
 @dataclass(frozen=True)
@@ -127,8 +130,10 @@ class JobManager:
             original_url=original_url,
             normalized_url=normalized_url,
             queue_position_at_submit=queued_count + 1,
+            delivery_request_id=request_id,
         )
         job.result_future = asyncio.get_running_loop().create_future()
+        job.delivery_future = asyncio.get_running_loop().create_future()
         job.requesters[request_id] = RequestRecord(
             request_id=request_id,
             chat_id=chat_id,
@@ -203,6 +208,10 @@ class JobManager:
             if request and request.active:
                 request.active = False
                 self.store.update_request_status(request_id, "cancelled")
+                if job.delivery_request_id == request_id and job.delivery_future and not job.delivery_future.done():
+                    self._handoff_delivery(job, request_id, asyncio.CancelledError())
+                elif job.delivery_request_id == request_id:
+                    self._promote_delivery_request(job)
                 if not any(item.active for item in job.requesters.values()):
                     if job.task and not job.task.done():
                         job.task.cancel()
@@ -228,6 +237,23 @@ class JobManager:
     def mark_request_failed(self, request_id: str, status: str = "failed") -> None:
         self.store.update_request_status(request_id, status)
         self._deactivate_request(request_id)
+
+    def is_delivery_request(self, job: SharedJob, request_id: str) -> bool:
+        request = job.requesters.get(request_id)
+        return bool(request and request.active and job.delivery_request_id == request_id)
+
+    async def wait_for_delivery(self, job: SharedJob) -> bool:
+        if job.delivery_future:
+            return await job.delivery_future
+        return False
+
+    def mark_delivery_completed(self, job: SharedJob) -> None:
+        job.last_delivery_error = None
+        if job.delivery_future and not job.delivery_future.done():
+            job.delivery_future.set_result(True)
+
+    def mark_delivery_failed(self, job: SharedJob, request_id: str, error: Exception) -> bool:
+        return self._handoff_delivery(job, request_id, error)
 
     def get_snapshot(self, chat_id: int) -> dict[str, int]:
         active = 0
@@ -266,11 +292,41 @@ class JobManager:
             request = job.requesters.get(request_id)
             if request:
                 request.active = False
+                if job.delivery_request_id == request_id and not (
+                    job.delivery_future and job.delivery_future.done()
+                ):
+                    self._promote_delivery_request(job)
                 if job.state in {"completed", "failed", "cancelled"} and not any(
                     item.active for item in job.requesters.values()
                 ):
                     self._jobs.pop(job_id, None)
                 return
+
+    def _promote_delivery_request(self, job: SharedJob) -> None:
+        next_request_id = self._next_delivery_request_id(job)
+        job.delivery_request_id = next_request_id
+
+    def _next_delivery_request_id(self, job: SharedJob, *, exclude_request_id: str | None = None) -> str | None:
+        active_requests = [
+            request for request in job.requesters.values()
+            if request.active and request.request_id != exclude_request_id
+        ]
+        if not active_requests:
+            return None
+        active_requests.sort(key=lambda item: item.created_monotonic)
+        return active_requests[0].request_id
+
+    def _handoff_delivery(self, job: SharedJob, failed_request_id: str, error: Exception) -> bool:
+        next_request_id = self._next_delivery_request_id(job, exclude_request_id=failed_request_id)
+        current_future = job.delivery_future
+        job.last_delivery_error = error
+        if current_future and not current_future.done():
+            current_future.set_result(False)
+        job.delivery_request_id = next_request_id
+        if next_request_id is None:
+            return False
+        job.delivery_future = asyncio.get_running_loop().create_future()
+        return True
 
     def _get_chat_semaphore(self, chat_id: int) -> asyncio.Semaphore:
         limits = self.store.get_queue_limits(chat_id)

--- a/src/instagram_video_bot/services/job_manager.py
+++ b/src/instagram_video_bot/services/job_manager.py
@@ -303,8 +303,14 @@ class JobManager:
                 return
 
     def _promote_delivery_request(self, job: SharedJob) -> None:
+        current_future = job.delivery_future
         next_request_id = self._next_delivery_request_id(job)
         job.delivery_request_id = next_request_id
+        job.last_delivery_error = None
+        if current_future and not current_future.done():
+            current_future.set_result(False)
+        if next_request_id is not None:
+            job.delivery_future = asyncio.get_running_loop().create_future()
 
     def _next_delivery_request_id(self, job: SharedJob, *, exclude_request_id: str | None = None) -> str | None:
         active_requests = [

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -43,6 +43,7 @@ class RequestContext:
     original_message_id: int
     status_message: Message
     quiet_mode: bool
+    joined_existing: bool
 
 
 class TelegramBot:
@@ -83,9 +84,6 @@ class TelegramBot:
             )
 
         for parsed_link in extracted_links:
-            status_message = await update.message.reply_text(
-                self._build_submission_message(parsed_link.provider_label, queue_position=1)
-            )
             submission = self.job_manager.submit(
                 chat_id=update.effective_chat.id,
                 user_id=update.effective_user.id,
@@ -97,6 +95,13 @@ class TelegramBot:
                 execute=self._build_job_executor(update.effective_chat.id, parsed_link),
                 duplicate_suppression=group_settings["duplicate_suppression"],
             )
+            status_message = await update.message.reply_text(
+                self._build_submission_message(
+                    parsed_link.provider_label,
+                    queue_position=submission.queue_position,
+                    joined_existing=not submission.is_new_job,
+                )
+            )
             request_context = RequestContext(
                 request_id=submission.request_id,
                 chat_id=update.effective_chat.id,
@@ -107,16 +112,9 @@ class TelegramBot:
                 original_message_id=update.message.message_id,
                 status_message=status_message,
                 quiet_mode=group_settings["quiet_mode"],
+                joined_existing=not submission.is_new_job,
             )
             self.request_contexts[submission.request_id] = request_context
-            await self._safe_edit_text(
-                status_message,
-                self._build_submission_message(
-                    parsed_link.provider_label,
-                    queue_position=submission.queue_position,
-                    joined_existing=not submission.is_new_job,
-                ),
-            )
             task = asyncio.create_task(self._await_request(context, request_context, submission.job))
             self.active_request_tasks[submission.request_id] = task
             task.add_done_callback(lambda _task, rid=submission.request_id: self._cleanup_request_task(rid))
@@ -305,17 +303,38 @@ class TelegramBot:
             if not job.result_future:
                 raise DownloadError("Job result future was not initialized")
             video_info = await job.result_future
-            if not request_context.quiet_mode:
-                await self._safe_edit_text(
-                    request_context.status_message,
-                    "📤 Uploading result..."
-                )
-            await self._send_media(context, request_context, video_info)
-            cache_suffix = " (cache hit)" if video_info.from_cache else ""
-            await self._safe_edit_text(
-                request_context.status_message,
-                f"✅ Done{cache_suffix}."
-            )
+            while True:
+                if self.job_manager.is_delivery_request(job, request_context.request_id):
+                    try:
+                        await self._send_media(context, request_context, video_info)
+                    except Exception as error:
+                        handed_off = self.job_manager.mark_delivery_failed(
+                            job,
+                            request_context.request_id,
+                            error,
+                        )
+                        if handed_off:
+                            logger.warning(
+                                "Delivery handoff triggered after Telegram send failure",
+                                extra={
+                                    "request_id": request_context.request_id,
+                                    "job_id": job.job_id,
+                                    "chat_id": request_context.chat_id,
+                                },
+                            )
+                            continue
+                        raise
+                    self.job_manager.mark_delivery_completed(job)
+                    break
+                delivered = await self.job_manager.wait_for_delivery(job)
+                if delivered:
+                    break
+                if job.delivery_request_id is not None:
+                    continue
+                if job.last_delivery_error is not None:
+                    raise job.last_delivery_error
+                raise RuntimeError("Shared delivery finished without a result")
+            await self._delete_status_message(request_context.status_message)
             self.job_manager.mark_request_completed(
                 request_context.request_id,
                 cache_hit=video_info.from_cache,
@@ -332,10 +351,14 @@ class TelegramBot:
         except VideoDownloadError as error:
             error_message = self._build_error_message(error)
             logger.error("Download error for %s: %s", request_context.original_url, error)
+            if self.job_manager.is_delivery_request(job, request_context.request_id):
+                self.job_manager.mark_delivery_failed(job, request_context.request_id, error)
             await self._safe_edit_text(request_context.status_message, error_message)
             self.job_manager.mark_request_failed(request_context.request_id, status="failed")
         except Exception as error:
             logger.exception("Unexpected error while delivering %s", request_context.original_url)
+            if self.job_manager.is_delivery_request(job, request_context.request_id):
+                self.job_manager.mark_delivery_failed(job, request_context.request_id, error)
             await self._safe_edit_text(
                 request_context.status_message,
                 "❌ An unexpected error occurred. Please try again later."
@@ -395,14 +418,16 @@ class TelegramBot:
             if request_id not in job.requesters:
                 continue
             if job.state == "running":
-                if request_context.quiet_mode:
+                if request_context.quiet_mode or request_context.joined_existing:
                     continue
                 text = f"⬇️ {request_context.provider_label} downloading..."
+                await self._edit_status_message(request_context.status_message, text)
             elif job.state == "cancelled":
                 text = "🛑 Request cancelled."
+                await self._safe_edit_text(request_context.status_message, text)
             else:
                 text = "❌ Download failed."
-            await self._safe_edit_text(request_context.status_message, text)
+                await self._safe_edit_text(request_context.status_message, text)
 
     async def _global_error_handler(
         self, update: object, context: ContextTypes.DEFAULT_TYPE
@@ -561,7 +586,16 @@ class TelegramBot:
         return f"❌ Sorry, couldn't download the media: {str(error)}"
 
     @staticmethod
+    async def _edit_status_message(message: Message, text: str) -> None:
+        """Try to edit a transient status message without creating extra chat noise."""
+        try:
+            await message.edit_text(text)
+        except Exception:
+            logger.debug("Failed to edit transient status message", exc_info=True)
+
+    @staticmethod
     async def _safe_edit_text(message: Message, text: str) -> None:
+        """Edit status text, falling back to a new visible reply for important states."""
         try:
             await message.edit_text(text)
         except Exception:
@@ -569,6 +603,14 @@ class TelegramBot:
                 await message.reply_text(text)
             except Exception:
                 logger.debug("Failed to edit or reply with status update", exc_info=True)
+
+    @staticmethod
+    async def _delete_status_message(message: Message) -> None:
+        """Delete a transient status message after successful completion."""
+        try:
+            await message.delete()
+        except Exception:
+            logger.debug("Failed to delete transient status message", exc_info=True)
 
     @staticmethod
     def _user_label(update: Update) -> str:

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+from src.instagram_video_bot.services.job_manager import JobManager, RequestRecord, SharedJob
+from src.instagram_video_bot.services.state_store import StateStore
+
+
+@pytest.mark.asyncio
+async def test_promote_delivery_request_wakes_waiters_and_rotates_future(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    manager = JobManager(store)
+    job = SharedJob(
+        job_id="job-1",
+        chat_id=77,
+        submitter_user_id=1001,
+        provider="instagram",
+        provider_label="Instagram",
+        original_url="https://www.instagram.com/reel/a/",
+        normalized_url="https://www.instagram.com/reel/a/",
+        delivery_request_id="req-1",
+        requesters={
+            "req-1": RequestRecord(request_id="req-1", chat_id=77, user_id=1001, user_label="alice"),
+            "req-2": RequestRecord(request_id="req-2", chat_id=77, user_id=1002, user_label="bob"),
+        },
+    )
+    old_future = asyncio.get_running_loop().create_future()
+    job.delivery_future = old_future
+    manager._jobs[job.job_id] = job
+    store.create_job(job.job_id, job.chat_id, job.normalized_url, job.provider, "running")
+    store.create_request("req-1", job.job_id, job.chat_id, 1001, "alice", job.provider, job.normalized_url, "running")
+    store.create_request("req-2", job.job_id, job.chat_id, 1002, "bob", job.provider, job.normalized_url, "running")
+
+    waiter = asyncio.create_task(manager.wait_for_delivery(job))
+    await asyncio.sleep(0)
+
+    manager.mark_request_failed("req-1", status="cancelled")
+
+    assert await waiter is False
+    assert job.delivery_request_id == "req-2"
+    assert job.delivery_future is not old_future
+    assert job.delivery_future is not None
+    assert job.delivery_future.done() is False

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -29,6 +29,7 @@ class _FakeBot:
 class _FakeStatusMessage:
     def __init__(self):
         self.texts = []
+        self.deleted = False
 
     async def edit_text(self, text: str):
         self.texts.append(text)
@@ -37,23 +38,38 @@ class _FakeStatusMessage:
         self.texts.append(text)
         return self
 
+    async def delete(self):
+        self.deleted = True
+
 
 class _FakeMessage:
-    def __init__(self, text: str):
+    def __init__(self, text: str, message_id: int = 10):
         self.text = text
-        self.message_id = 10
+        self.message_id = message_id
         self.replies = []
+        self.status_messages = []
 
     async def reply_text(self, text: str):
         self.replies.append(text)
-        return _FakeStatusMessage()
+        status_message = _FakeStatusMessage()
+        self.status_messages.append(status_message)
+        return status_message
 
 
 class _FakeUpdate:
-    def __init__(self, text: str):
-        self.message = _FakeMessage(text)
-        self.effective_chat = SimpleNamespace(id=77)
-        self.effective_user = SimpleNamespace(id=1001, username="alice", full_name="Alice")
+    def __init__(
+        self,
+        text: str,
+        *,
+        chat_id: int = 77,
+        user_id: int = 1001,
+        username: str = "alice",
+        full_name: str = "Alice",
+        message_id: int = 10,
+    ):
+        self.message = _FakeMessage(text, message_id=message_id)
+        self.effective_chat = SimpleNamespace(id=chat_id)
+        self.effective_user = SimpleNamespace(id=user_id, username=username, full_name=full_name)
 
 
 class _FakeContext:
@@ -74,6 +90,7 @@ def _make_request_context(status_message: _FakeStatusMessage) -> RequestContext:
         original_message_id=10,
         status_message=status_message,
         quiet_mode=False,
+        joined_existing=False,
     )
 
 
@@ -181,6 +198,44 @@ async def test_handle_message_processes_request_in_background(monkeypatch, tmp_p
 
     assert not media_file.exists()
     assert len(fake_bot.video_calls) == 1
+    assert update.message.replies == ["🕓 Instagram accepted. Starting shortly."]
+    assert update.message.status_messages[0].texts == ["⬇️ Instagram downloading..."]
+    assert update.message.status_messages[0].deleted is True
+
+
+@pytest.mark.asyncio
+async def test_duplicate_suppressed_requests_send_media_only_once(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    first_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1001, username="alice", full_name="Alice", message_id=10)
+    second_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1002, username="bob", full_name="Bob", message_id=11)
+
+    media_file = tmp_path / "shared.mp4"
+    media_file.write_bytes(b"video")
+
+    async def fake_download_video(self, url: str, output_dir: Path):
+        await asyncio.sleep(0)
+        return VideoInfo(
+            file_path=media_file,
+            title="shared",
+            media_items=[MediaItem(file_path=media_file, media_type="video")],
+            primary_media_type="video",
+        )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.RESULT_CACHE_ENABLED", False)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader.download_video", fake_download_video)
+
+    await telegram_bot.handle_message(first_update, context)
+    await telegram_bot.handle_message(second_update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert len(fake_bot.video_calls) == 1
+    assert fake_bot.video_calls[0]["reply_to_message_id"] == 10
+    assert first_update.message.status_messages[0].deleted is True
+    assert second_update.message.status_messages[0].deleted is True
+    assert second_update.message.replies == ["🔁 Instagram already in progress. Waiting for the shared result."]
+    assert second_update.message.status_messages[0].texts == []
 
 
 @pytest.mark.parametrize(
@@ -211,6 +266,46 @@ def test_build_caption_text_truncates_long_titles():
 
     assert len(caption) == TelegramBot.MAX_MEDIA_CAPTION_LENGTH
     assert caption.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_shared_delivery_handoffs_to_another_requester_on_send_failure(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    context = _FakeContext(_FakeBot())
+    first_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1001, username="alice", full_name="Alice", message_id=10)
+    second_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1002, username="bob", full_name="Bob", message_id=11)
+
+    media_file = tmp_path / "handoff.mp4"
+    media_file.write_bytes(b"video")
+    delivered_message_ids = []
+
+    async def fake_download_video(self, url: str, output_dir: Path):
+        await asyncio.sleep(0)
+        return VideoInfo(
+            file_path=media_file,
+            title="handoff",
+            media_items=[MediaItem(file_path=media_file, media_type="video")],
+            primary_media_type="video",
+        )
+
+    async def fake_send_media(self, context, request_context, video_info):
+        if request_context.original_message_id == 10:
+            raise RuntimeError("telegram send failed")
+        delivered_message_ids.append(request_context.original_message_id)
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.RESULT_CACHE_ENABLED", False)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader.download_video", fake_download_video)
+    monkeypatch.setattr(TelegramBot, "_send_media", fake_send_media)
+
+    await telegram_bot.handle_message(first_update, context)
+    await telegram_bot.handle_message(second_update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert delivered_message_ids == [11]
+    assert first_update.message.status_messages[0].deleted is True
+    assert second_update.message.status_messages[0].deleted is True
+    assert first_update.message.status_messages[0].texts == ["⬇️ Instagram downloading..."]
+    assert second_update.message.status_messages[0].texts == []
 
 
 @pytest.mark.asyncio
@@ -255,6 +350,41 @@ async def test_quiet_mode_skips_running_status_updates(tmp_path):
         original_message_id=10,
         status_message=status_message,
         quiet_mode=True,
+        joined_existing=False,
+    )
+    telegram_bot.request_contexts["req-1"] = request_context
+    job = SharedJob(
+        job_id="job-1",
+        chat_id=77,
+        submitter_user_id=1001,
+        provider="instagram",
+        provider_label="Instagram",
+        original_url=request_context.original_url,
+        normalized_url=request_context.normalized_url,
+        state="running",
+        requesters={"req-1": RequestRecord(request_id="req-1", chat_id=77, user_id=1001, user_label="alice")},
+    )
+
+    await telegram_bot._on_job_state_change(job)
+
+    assert status_message.texts == []
+
+
+@pytest.mark.asyncio
+async def test_joined_existing_request_skips_running_status_updates(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    status_message = _FakeStatusMessage()
+    request_context = RequestContext(
+        request_id="req-1",
+        chat_id=77,
+        user_id=1001,
+        provider_label="Instagram",
+        normalized_url="https://www.instagram.com/reel/a/",
+        original_url="https://www.instagram.com/reel/a/",
+        original_message_id=10,
+        status_message=status_message,
+        quiet_mode=False,
+        joined_existing=True,
     )
     telegram_bot.request_contexts["req-1"] = request_context
     job = SharedJob(


### PR DESCRIPTION
## Summary
- delete transient status messages on success instead of posting terminal Done messages
- avoid duplicate shared-job delivery by sending media only once per normalized URL in a chat
- hand off shared delivery to another active requester if the chosen Telegram send fails

## Testing
- uv run pytest -q