### PR TITLE
Add Russian chaos mode

### DIFF
--- a/docs/superpowers/plans/2026-04-23-chaos-mode.md
+++ b/docs/superpowers/plans/2026-04-23-chaos-mode.md
@@ -1,0 +1,329 @@
+# Chaos Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-chat opt-in Russian Chaos Mode for Telegram messages, commands, duplicate/cache moments, and stats without changing downloader behavior.
+
+**Architecture:** Extend `StateStore` with one chat setting and one duplicate marker, add a focused `chaos_text.py` renderer for Russian text, and integrate it through `TelegramBot` at existing command and request lifecycle boundaries. Keep provider downloaders and queue execution unchanged.
+
+**Tech Stack:** Python 3.11, python-telegram-bot, SQLite via `sqlite3`, pytest/pytest-asyncio, uv.
+
+---
+
+## File Map
+
+- Create `src/instagram_video_bot/services/chaos_text.py`: Russian text renderer for normal and chaos-mode bot messages.
+- Modify `src/instagram_video_bot/services/state_store.py`: persist `chaos_mode_enabled`, record duplicate-joined requests, and expose enriched group stats.
+- Modify `src/instagram_video_bot/services/job_manager.py`: pass `joined_existing=True` into persisted duplicate request rows.
+- Modify `src/instagram_video_bot/services/telegram_bot.py`: register `/chaos`, translate user-facing text to Russian, use renderer for lifecycle/status/error/stats text, and enforce admin-or-owner permission for `/chaos`.
+- Modify `tests/test_telegram_bot_media_send.py`: update Russian expectations and add command/lifecycle tests.
+- Create `tests/test_chaos_text.py`: renderer unit coverage.
+- Create `tests/test_state_store_chaos.py`: persistence and stats coverage.
+
+## Task 1: Persist Chaos Mode and Duplicate Joins
+
+**Files:**
+- Modify: `src/instagram_video_bot/services/state_store.py`
+- Modify: `src/instagram_video_bot/services/job_manager.py`
+- Create: `tests/test_state_store_chaos.py`
+
+- [ ] **Step 1: Write failing state-store tests**
+
+Create `tests/test_state_store_chaos.py` with:
+
+```python
+from src.instagram_video_bot.services.state_store import StateStore
+
+
+def test_group_settings_include_disabled_chaos_mode_by_default(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+
+    settings = store.ensure_group_settings(77)
+
+    assert settings["chaos_mode_enabled"] is False
+
+
+def test_group_settings_can_enable_chaos_mode(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+
+    settings = store.update_group_settings(77, chaos_mode_enabled=True)
+
+    assert settings["chaos_mode_enabled"] is True
+    assert store.ensure_group_settings(77)["chaos_mode_enabled"] is True
+
+
+def test_group_stats_include_cache_hits_duplicate_joins_and_provider_counts(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    store.create_job("job-1", 77, "https://x.com/a/status/1", "twitter", "queued")
+    store.create_request(
+        "req-1",
+        "job-1",
+        77,
+        1001,
+        "@alice",
+        "twitter",
+        "https://x.com/a/status/1",
+        "queued",
+    )
+    store.create_request(
+        "req-2",
+        "job-1",
+        77,
+        1002,
+        "@bob",
+        "twitter",
+        "https://x.com/a/status/1",
+        "queued",
+        joined_existing=True,
+    )
+    store.update_request_status("req-1", "completed", cache_hit=True)
+    store.update_request_status("req-2", "completed")
+
+    stats = store.get_group_stats(77)
+
+    assert stats["completed"] == 2
+    assert stats["cache_hits"] == 1
+    assert stats["duplicate_joins"] == 1
+    assert stats["top_providers"] == [("twitter", 2)]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_state_store_chaos.py -q`
+
+Expected: FAIL because `chaos_mode_enabled` and `joined_existing` are not persisted yet.
+
+- [ ] **Step 3: Implement persistence**
+
+Update `StateStore._initialize()` to add `chaos_mode_enabled INTEGER NOT NULL DEFAULT 0` to `group_settings` and `joined_existing INTEGER NOT NULL DEFAULT 0` to `request_events`, with migration checks for existing databases.
+
+Update `ensure_group_settings()` to return `chaos_mode_enabled`, `update_group_settings()` to allow it, and `create_request()` to accept `joined_existing: bool = False`.
+
+Update `get_group_stats()` to include `cache_hits`, `duplicate_joins`, and existing provider/user aggregates.
+
+Update `JobManager.submit()` so duplicate-suppressed existing jobs call `create_request(..., joined_existing=True)`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/test_state_store_chaos.py -q`
+
+Expected: PASS.
+
+## Task 2: Add Russian Text Renderer
+
+**Files:**
+- Create: `src/instagram_video_bot/services/chaos_text.py`
+- Create: `tests/test_chaos_text.py`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Create `tests/test_chaos_text.py` with:
+
+```python
+from src.instagram_video_bot.services.chaos_text import ChaosText, TextContext
+
+
+def test_normal_submission_text_is_russian():
+    text = ChaosText.submission(
+        TextContext(provider_label="Instagram", chaos_enabled=False),
+        queue_position=1,
+        joined_existing=False,
+    )
+
+    assert text == "Принял Instagram. Скоро начну скачивать."
+
+
+def test_chaos_submission_text_is_russian_and_provider_aware():
+    text = ChaosText.submission(
+        TextContext(provider_label="Twitter/X", chaos_enabled=True),
+        queue_position=1,
+        joined_existing=False,
+    )
+
+    assert "Twitter/X" in text
+    assert "шум" in text.lower()
+
+
+def test_chaos_duplicate_text_is_russian():
+    text = ChaosText.submission(
+        TextContext(provider_label="Instagram", chaos_enabled=True),
+        queue_position=1,
+        joined_existing=True,
+    )
+
+    assert "уже" in text.lower()
+    assert "Instagram" in text
+
+
+def test_error_text_is_russian_for_rate_limit():
+    text = ChaosText.error(RuntimeError("rate limit"), chaos_enabled=False)
+
+    assert "лимит" in text.lower()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_chaos_text.py -q`
+
+Expected: FAIL because `chaos_text.py` does not exist yet.
+
+- [ ] **Step 3: Implement renderer**
+
+Create `chaos_text.py` with `TextContext` and `ChaosText` static/class methods for:
+
+- `help()`
+- `formats()`
+- `submission()`
+- `running()`
+- `cancelled()`
+- `failed()`
+- `unexpected_error()`
+- `error()`
+- `stats_disabled()`
+- `stats()`
+- `setting_usage()`
+- `setting_updated()`
+- `numeric_setting_usage()`
+- `numeric_setting_updated()`
+- `owner_unconfigured()`
+- `owner_required()`
+- `chaos_usage()`
+- `chaos_status()`
+- `chaos_updated()`
+- `admin_required()`
+
+Use Russian user-facing strings only. Keep internal method names English.
+
+- [ ] **Step 4: Run renderer tests**
+
+Run: `uv run pytest tests/test_chaos_text.py -q`
+
+Expected: PASS.
+
+## Task 3: Wire Chaos Command and Russian Command Text
+
+**Files:**
+- Modify: `src/instagram_video_bot/services/telegram_bot.py`
+- Modify: `tests/test_telegram_bot_media_send.py`
+
+- [ ] **Step 1: Write failing command tests**
+
+Add tests proving:
+
+- `/chaos on` enables `chaos_mode_enabled` when the sender is the bot owner.
+- `/chaos off` disables it.
+- `/chaos status` reports Russian enabled/disabled status.
+- non-owner/non-admin group users are rejected with Russian text.
+- `/help`, `/formats`, `/status`, and `/stats` produce Russian text.
+
+- [ ] **Step 2: Run selected tests to verify failure**
+
+Run: `uv run pytest tests/test_telegram_bot_media_send.py -q`
+
+Expected: FAIL because command text and `/chaos` are not implemented yet.
+
+- [ ] **Step 3: Implement command integration**
+
+In `TelegramBot`:
+
+- Import `ChaosText` and `TextContext`.
+- Add `chaos_command()`.
+- Register `CommandHandler("chaos", self.chaos_command)`.
+- Implement `_require_chaos_admin(update, context)`:
+  - private chat: allow sender
+  - bot owner: allow sender
+  - group/supergroup: allow Telegram `creator` or `administrator`
+  - otherwise reply with Russian admin-required text
+- Rewrite `/help`, `/formats`, `/status`, `/stats`, owner guard messages, and generic setting/numeric setting responses through `ChaosText`.
+
+- [ ] **Step 4: Run command tests**
+
+Run: `uv run pytest tests/test_telegram_bot_media_send.py -q`
+
+Expected: PASS.
+
+## Task 4: Wire Lifecycle Chaos Text
+
+**Files:**
+- Modify: `src/instagram_video_bot/services/telegram_bot.py`
+- Modify: `tests/test_telegram_bot_media_send.py`
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add tests proving:
+
+- normal request submission text is Russian when Chaos Mode is off.
+- running status text is Russian when Chaos Mode is off.
+- duplicate-joined text is Russian and playful when Chaos Mode is on.
+- cache-hit successful flow records a cache hit and uses the Russian status/caption behavior without changing media delivery.
+- failure text is Russian and uses the existing error categories.
+
+- [ ] **Step 2: Run selected tests to verify failure**
+
+Run: `uv run pytest tests/test_telegram_bot_media_send.py -q`
+
+Expected: FAIL until lifecycle methods use `ChaosText`.
+
+- [ ] **Step 3: Implement lifecycle integration**
+
+In `handle_message()`, read `chaos_mode_enabled` from group settings and pass it into submission/status rendering.
+
+In `_on_job_state_change()`, render running/cancelled/failed text through `ChaosText`, while preserving quiet-mode and joined-existing running suppression.
+
+In `_await_request()`, render `VideoDownloadError` and unexpected errors through `ChaosText.error()` and `ChaosText.unexpected_error()`.
+
+In `_build_caption_text()`, switch the prefix to Russian-friendly media caption text while keeping length truncation behavior.
+
+- [ ] **Step 4: Run lifecycle tests**
+
+Run: `uv run pytest tests/test_telegram_bot_media_send.py -q`
+
+Expected: PASS.
+
+## Task 5: Full Verification and Commit
+
+**Files:**
+- All changed files.
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest -q`
+
+Expected: 70+ tests pass with only the existing `test_proxies.py::test_all_proxies` return-value warning unless new tests increase the count.
+
+- [ ] **Step 2: Inspect git diff**
+
+Run: `git diff --stat`
+
+Expected: changes are limited to Chaos Mode implementation, tests, and this plan.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add -f docs/superpowers/plans/2026-04-23-chaos-mode.md
+git add src/instagram_video_bot/services/chaos_text.py src/instagram_video_bot/services/state_store.py src/instagram_video_bot/services/job_manager.py src/instagram_video_bot/services/telegram_bot.py tests/test_chaos_text.py tests/test_state_store_chaos.py tests/test_telegram_bot_media_send.py
+git commit -m "feat: add russian chaos mode"
+```
+
+Expected: commit succeeds on branch `codex/chaos-mode`.
+
+## Self-Review
+
+Spec coverage:
+
+- per-chat opt-in setting: Task 1 and Task 3
+- admin-controlled `/chaos`: Task 3
+- Russian user-facing text: Task 2, Task 3, Task 4
+- event-driven lifecycle rendering: Task 4
+- duplicate/cache/stats flavor: Task 1, Task 2, Task 4
+- downloader behavior unchanged: Task 4 and Task 5 verification
+
+Placeholder scan:
+
+- No `TBD`, `TODO`, incomplete sections, or intentionally vague "handle later" steps.
+
+Type consistency:
+
+- `chaos_mode_enabled`, `joined_existing`, `ChaosText`, and `TextContext` names are used consistently across tasks.

--- a/docs/superpowers/specs/2026-04-23-chaos-mode-design.md
+++ b/docs/superpowers/specs/2026-04-23-chaos-mode-design.md
@@ -1,0 +1,274 @@
+# Chaos Mode Design
+
+Date: 2026-04-23
+Repo: `/Users/ozaytsev/Softs/Inst_video_downloader_tg_bot`
+Status: Approved for planning
+
+## Summary
+
+Add an opt-in, admin-controlled `Chaos Mode` that makes the Telegram bot feel funny, loud, and distinctly Russian without changing the downloader core. The feature targets both private chats and group chats, but it is enabled per chat by admins. When enabled, the bot becomes actively chatty around real events such as queueing, duplicate suppression, cache hits, successful downloads, failures, and streak milestones.
+
+The current bot already has the right primitives for this: provider-aware request parsing, shared-job queueing, duplicate suppression, recent-result caching, lightweight group stats, and chat-level settings. The design extends those primitives rather than introducing a parallel game system.
+
+## Goals
+
+- Make the bot feel memorable and entertaining in both private and group chats.
+- Keep all user-facing bot text in Russian.
+- Preserve the current downloader behavior and queue semantics.
+- Reuse existing chat-level settings, stats, cache, and job lifecycle events.
+- Keep the first implementation slice small enough to ship safely.
+
+## Non-Goals
+
+- Rewriting downloader/provider logic for Instagram, Twitter/X, or YouTube Shorts.
+- Building a deep lore engine, weekly seasons, or complicated rivalry mechanics in v1.
+- Translating internal code, logs, identifiers, or tests into Russian.
+- Adding timer-based random chatter unrelated to real bot events.
+
+## Current Codebase Fit
+
+The feature is intentionally layered on top of the current architecture:
+
+- `src/instagram_video_bot/services/request_parser.py` already identifies provider type and normalizes supported links.
+- `src/instagram_video_bot/services/telegram_bot.py` already owns the command surface and request lifecycle messages.
+- `src/instagram_video_bot/services/job_manager.py` already provides the event boundaries that matter for chatty UX: queued, running, completed, failed, cancelled, joined-existing-job, and delivery ownership handoff.
+- `src/instagram_video_bot/services/state_store.py` already persists per-chat settings, request/job state, cached results, and lightweight stats.
+
+This means Chaos Mode should be implemented as a presentation and social-state layer, not as a new execution subsystem.
+
+## Product Rules
+
+- Chaos Mode is disabled by default.
+- Chaos Mode is enabled per chat, not per user.
+- In group chats, admins control the mode.
+- In private chats, the user in that dialog can toggle the mode for that private chat.
+- All Telegram-facing text is written directly in Russian.
+- Humor is opt-in, actively chatty, and event-driven.
+- Existing useful behavior remains intact when Chaos Mode is off.
+
+## User Experience
+
+### Default Mode
+
+When Chaos Mode is off, the bot stays functionally the same as today: practical, lower-noise, and utility-first.
+
+### Chaos Mode
+
+When Chaos Mode is on:
+
+- queue and status messages become playful and Russian-language
+- duplicate suppression becomes visible and funny instead of silently functional
+- cache hits feel like instant "summons"
+- successful downloads can trigger short celebration text
+- failures become informative but dramatic instead of flat
+- stats gain funny Russian titles and labels
+
+The bot should feel energetic, but not random. It speaks when something real happened.
+
+### Tone
+
+The target tone is Russian-first, Telegram-native, short, readable, and intentionally mischievous. It should avoid direct translation of English meme slang, overlong copypasta, or hostility that turns the bot into a nuisance.
+
+Tone differences by chat type:
+
+- Group chat: louder, more teasing, more arena-like.
+- Private chat: still funny, but more personal and less confrontational.
+
+## Commands
+
+### V1 Commands
+
+- `/chaos on` - enable Chaos Mode for the current chat.
+- `/chaos off` - disable Chaos Mode for the current chat.
+- `/chaos status` - report whether Chaos Mode is active for the current chat.
+- `/help` - rewritten in Russian and updated to mention Chaos Mode.
+- `/formats` - rewritten in Russian and updated examples if needed.
+- `/stats` - keeps current utility, but adds Russian chaotic labels when Chaos Mode is active.
+
+### Deferred Commands
+
+These are explicitly out of scope for v1:
+
+- `/streak`
+- `/legend`
+- `/lore`
+- `/mood`
+- reply-based "summon" commands
+
+They can be added later if v1 tone and noise levels work well in real usage.
+
+## Event Model
+
+Chaos Mode text is generated only for real request lifecycle events. There is no timer-based chatter.
+
+### Event Classes
+
+- request queued
+- request joined an existing shared job
+- queue or per-user limit reached
+- cache hit
+- download started or promoted into visible progress
+- successful delivery
+- failure
+- cancellation
+- stats response
+
+### Provider Awareness
+
+The renderer should be aware of:
+
+- Instagram
+- Twitter/X
+- YouTube Shorts
+
+Each provider gets slightly different Russian phrasing so the bot feels intentional instead of using one generic joke pool for everything.
+
+## Data Model
+
+### Chat Settings
+
+Extend `group_settings` with:
+
+- `chaos_mode_enabled`
+
+Possible future fields, but not required for v1:
+
+- `chaos_roasts_enabled`
+- `chaos_stats_enabled`
+- `chaos_level`
+
+For v1, a single boolean is enough and keeps rollout simple.
+
+### Social Stats
+
+Add lightweight per-chat, per-user counters. These should be stored as event counters or derived stats, not as generated prose.
+
+Recommended counters for v1:
+
+- successful download count
+- cache-hit count
+- duplicate-join count
+- current simple streak
+- preferred provider count distribution
+
+This data supports funny stats without binding the system to any specific wording.
+
+### Storage Principle
+
+Store facts, not jokes. Russian text should be rendered at response time from templates based on event type, provider, chat type, and a small amount of social context.
+
+## Message Generation Rules
+
+### Core Principle
+
+The bot must be actively chatty, but still event-bounded.
+
+### Message Strategy
+
+- Prefer editing an existing status message instead of sending a new message.
+- Use short lines for normal flow.
+- Use bigger, more animated phrasing only for meaningful moments.
+- Keep a small template pool per event class to avoid repetition.
+- Apply provider-specific variants where useful.
+- Apply chat-type variants where useful.
+
+### Anti-Noise Rules
+
+- Respect existing `/quiet` behavior as a stronger limiter than Chaos Mode.
+- Do not emit extra messages purely for flavor if an edit covers the event.
+- Add cooldowns for repeated joke categories so the same roast does not appear constantly.
+- Do not create a second stream of commentary detached from request execution.
+
+This keeps the feature consistent with the repo's recent status-noise cleanup direction while still delivering a noticeably louder personality when enabled.
+
+## Russian Language Rule
+
+All user-facing text must be authored directly in Russian, including:
+
+- help text
+- formats text
+- queue/status text
+- success/failure text
+- stats labels
+- duplicate/cache/streak callouts
+
+Internal implementation can remain in English:
+
+- variable names
+- function names
+- class names
+- logs
+- tests
+
+This keeps maintenance practical while ensuring the product experience feels native.
+
+## Error Handling
+
+Chaos Mode must not change the underlying success/failure behavior of downloads.
+
+- If the download fails, users still get a truthful failure outcome.
+- If duplicate suppression merges a request into an existing job, semantics stay the same; only presentation changes.
+- If cached media is reused, semantics stay the same; Chaos Mode only changes how the hit is announced.
+- If Chaos Mode data is unavailable or a template path fails, the bot should fall back to plain Russian utility text rather than fail the request.
+
+The personality layer must degrade gracefully.
+
+## Testing Strategy
+
+Add or extend tests in four areas:
+
+- persistence tests for the new `chaos_mode_enabled` setting
+- command tests for `/chaos on`, `/chaos off`, and `/chaos status`
+- message-generation tests that verify Russian output selection for major event classes
+- behavior tests that confirm normal mode remains low-noise and queue semantics are unchanged
+
+Important invariants:
+
+- downloader/provider behavior does not change
+- duplicate suppression behavior does not change
+- cache-hit behavior does not change
+- command permissions stay correct for admin-controlled toggles
+
+## V1 Scope
+
+V1 includes:
+
+- per-chat `chaos_mode_enabled`
+- Russian rewrite of current public command/help/format text
+- Russian event templates for queued, duplicate join, cache hit, success, failure, cancellation, and limit-reached states
+- provider-aware flavor for Instagram, Twitter/X, and YouTube Shorts
+- lightweight social stats enrichment for funny `/stats` output
+- repetition control and basic anti-noise rules
+
+V1 explicitly excludes:
+
+- deep lore systems
+- weekly titles or seasons
+- rivalry engines
+- battle events spanning multiple concurrent users
+- large command surface expansion
+- downloader-core refactors
+
+## Recommended Implementation Order
+
+1. Add persistent chat-level Chaos Mode setting.
+2. Rewrite existing user-facing command/help/formats text into Russian.
+3. Introduce a message-rendering layer for Russian event templates.
+4. Attach Chaos Mode rendering to existing request lifecycle events.
+5. Add lightweight social stats used by `/stats`.
+6. Add test coverage for settings, commands, and message selection.
+
+## First-Slice Success Criteria
+
+The first release is successful if:
+
+- admins can enable or disable Chaos Mode per chat
+- the bot feels noticeably more alive when the mode is on
+- all user-facing bot text reads naturally in Russian
+- the bot remains usable in both private and group chats
+- no downloader behavior regresses
+- no large increase in noisy message spam appears outside approved event boundaries
+
+## Planning Note
+
+The next step after this design is a concrete implementation plan. That plan should keep v1 narrow and avoid mixing personality work with provider/downloader refactors unless tests reveal a hard dependency.

--- a/src/instagram_video_bot/services/chaos_text.py
+++ b/src/instagram_video_bot/services/chaos_text.py
@@ -94,12 +94,10 @@ class ChaosText:
                 return "Провайдер включил лимит. Отступаем, чтобы не получить по шапке."
             return "Достигнут лимит провайдера. Попробуй позже."
         if "unsupported" in error_lower:
-            return f"Неподдерживаемая ссылка: {error_text}"
+            return "Эта ссылка не поддерживается."
         if "timed out" in error_lower:
             return "Скачивание не уложилось по времени. Попробуй еще раз."
-        if chaos_enabled:
-            return f"Не смог скачать медиа. Причина без прикрас: {error_text}"
-        return f"Не смог скачать медиа: {error_text}"
+        return "Не смог скачать медиа. Попробуй позже."
 
     @staticmethod
     def stats_disabled() -> str:

--- a/src/instagram_video_bot/services/chaos_text.py
+++ b/src/instagram_video_bot/services/chaos_text.py
@@ -1,0 +1,220 @@
+"""Russian user-facing text for normal and chaos-mode bot responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TextContext:
+    """Rendering context for one Telegram-facing message."""
+
+    provider_label: str = ""
+    chaos_enabled: bool = False
+    private_chat: bool = False
+
+
+class ChaosText:
+    """Build Russian Telegram text without coupling it to bot control flow."""
+
+    @staticmethod
+    def help(chaos_enabled: bool) -> str:
+        chaos_line = (
+            "Режим хаоса включен: буду шумнее реагировать на очереди, повторы и удачные скачивания."
+            if chaos_enabled
+            else "Режим хаоса выключен. Админ может включить его командой /chaos on."
+        )
+        return (
+            "Пришли ссылку, а я скачаю медиа.\n"
+            "Поддерживаю: Instagram, Twitter/X и YouTube Shorts.\n"
+            "Команды: /help, /status, /formats, /cancel, /stats, /chaos status\n"
+            "Настройки владельца: /quiet on|off, /dupes on|off, /statsmode on|off, "
+            "/chatlimit <n>, /userlimit <n>, /admin_status\n"
+            f"{chaos_line}"
+        )
+
+    @staticmethod
+    def formats() -> str:
+        return (
+            "Поддерживаемые ссылки:\n"
+            "- Instagram: посты, reels, stories и share-ссылки\n"
+            "- Twitter/X: ссылки вида /status/...\n"
+            "- YouTube Shorts: ссылки /shorts/..."
+        )
+
+    @staticmethod
+    def submission(context: TextContext, *, queue_position: int, joined_existing: bool = False) -> str:
+        provider = context.provider_label
+        if joined_existing:
+            if context.chaos_enabled:
+                return f"{provider} уже в работе. Повтор засчитан, сидим рядом с таймером."
+            return f"{provider} уже скачивается. Дождусь общего результата."
+
+        if queue_position > 1:
+            ahead = queue_position - 1
+            if context.chaos_enabled:
+                return f"{provider} принят в очередь. Впереди еще {ahead}, в чате уже легкий шум."
+            return f"{provider} в очереди. Перед тобой: {ahead}."
+
+        if context.chaos_enabled:
+            return f"{provider} принят. Включаю шум, достаю медиа."
+        return f"Принял {provider}. Скоро начну скачивать."
+
+    @staticmethod
+    def running(context: TextContext) -> str:
+        if context.chaos_enabled:
+            return f"{context.provider_label}: пошла добыча, не моргаем."
+        return f"{context.provider_label}: скачиваю."
+
+    @staticmethod
+    def cancelled(chaos_enabled: bool) -> str:
+        if chaos_enabled:
+            return "Запрос отменен. Драма закончилась раньше скачивания."
+        return "Запрос отменен."
+
+    @staticmethod
+    def failed(chaos_enabled: bool) -> str:
+        if chaos_enabled:
+            return "Скачивание упало. Сейчас разберу завалы и скажу, что случилось."
+        return "Не удалось скачать медиа."
+
+    @staticmethod
+    def unexpected_error() -> str:
+        return "Произошла неожиданная ошибка. Попробуй позже."
+
+    @staticmethod
+    def error(error: Exception, *, chaos_enabled: bool) -> str:
+        error_text = str(error)
+        error_lower = error_text.lower()
+        if "authentication failed" in error_lower or "cookies have expired" in error_lower:
+            return "Не прошла авторизация Instagram. Владельцу бота нужно обновить сессию."
+        if "rate-limit" in error_lower or "rate limit" in error_lower:
+            if chaos_enabled:
+                return "Провайдер включил лимит. Отступаем, чтобы не получить по шапке."
+            return "Достигнут лимит провайдера. Попробуй позже."
+        if "unsupported" in error_lower:
+            return f"Неподдерживаемая ссылка: {error_text}"
+        if "timed out" in error_lower:
+            return "Скачивание не уложилось по времени. Попробуй еще раз."
+        if chaos_enabled:
+            return f"Не смог скачать медиа. Причина без прикрас: {error_text}"
+        return f"Не смог скачать медиа: {error_text}"
+
+    @staticmethod
+    def stats_disabled() -> str:
+        return "Статистика выключена для этого чата."
+
+    @staticmethod
+    def stats(stats: dict[str, Any], *, chaos_enabled: bool) -> str:
+        top_users = ", ".join(f"{name} ({count})" for name, count in stats["top_users"]) or "пока пусто"
+        top_providers = ", ".join(
+            f"{ChaosText.provider_name(provider)} ({count})" for provider, count in stats["top_providers"]
+        ) or "пока пусто"
+
+        if chaos_enabled:
+            return (
+                "Статистика хаоса:\n"
+                f"- Успешных добыч: {stats['completed']}\n"
+                f"- Падений: {stats['failed']}\n"
+                f"- Отмен: {stats['cancelled']}\n"
+                f"- Мгновенных возвратов из кэша: {stats['cache_hits']}\n"
+                f"- Повторных ссылок в ту же мясорубку: {stats['duplicate_joins']}\n"
+                f"- Главные поставщики ссылок: {top_users}\n"
+                f"- Любимые площадки: {top_providers}"
+            )
+
+        return (
+            "Статистика чата:\n"
+            f"- Успешно: {stats['completed']}\n"
+            f"- Ошибок: {stats['failed']}\n"
+            f"- Отменено: {stats['cancelled']}\n"
+            f"- Из кэша: {stats['cache_hits']}\n"
+            f"- Повторных ссылок: {stats['duplicate_joins']}\n"
+            f"- Топ пользователей: {top_users}\n"
+            f"- Топ площадок: {top_providers}"
+        )
+
+    @staticmethod
+    def status(snapshot: dict[str, int], persisted: dict[str, int], *, chaos_enabled: bool) -> str:
+        title = "Статус очереди хаоса" if chaos_enabled else "Статус очереди"
+        return (
+            f"{title}:\n"
+            f"- Активные задачи: {snapshot['active_jobs']}\n"
+            f"- В очереди: {snapshot['queued_jobs']}\n"
+            f"- Активные запросы: {snapshot['active_requests']}\n"
+            f"- Лимит чата: {snapshot['chat_limit']}\n"
+            f"- Лимит на пользователя: {snapshot['user_limit']}\n"
+            f"- Завершено: {persisted['completed']}\n"
+            f"- Ошибок: {persisted['failed']}\n"
+            f"- Попаданий в кэш: {persisted['cache_hits']}"
+        )
+
+    @staticmethod
+    def setting_usage(command_name: str) -> str:
+        return f"Использование: /{command_name} on|off"
+
+    @staticmethod
+    def setting_updated(label: str, enabled: bool) -> str:
+        state = "включено" if enabled else "выключено"
+        return f"{label}: {state}."
+
+    @staticmethod
+    def numeric_setting_usage(command_name: str) -> str:
+        return f"Использование: /{command_name} <положительное число>"
+
+    @staticmethod
+    def numeric_setting_updated(label: str, value: int) -> str:
+        return f"{label}: {value}."
+
+    @staticmethod
+    def owner_unconfigured() -> str:
+        return "Команды владельца недоступны: BOT_OWNER_USER_ID не настроен."
+
+    @staticmethod
+    def owner_required() -> str:
+        return "Эта команда доступна только владельцу бота."
+
+    @staticmethod
+    def chaos_usage() -> str:
+        return "Использование: /chaos on|off|status"
+
+    @staticmethod
+    def chaos_status(enabled: bool) -> str:
+        if enabled:
+            return "Режим хаоса включен для этого чата."
+        return "Режим хаоса выключен для этого чата."
+
+    @staticmethod
+    def chaos_updated(enabled: bool) -> str:
+        if enabled:
+            return "Режим хаоса включен. Теперь бот будет шуметь по делу."
+        return "Режим хаоса выключен. Возвращаюсь к спокойному режиму."
+
+    @staticmethod
+    def admin_required() -> str:
+        return "Режим хаоса могут переключать только админы чата или владелец бота."
+
+    @staticmethod
+    def no_active_request() -> str:
+        return "У тебя нет активных запросов в очереди или скачивании."
+
+    @staticmethod
+    def latest_cancelled() -> str:
+        return "Последний запрос отменен."
+
+    @staticmethod
+    def too_many_links(limit: int) -> str:
+        return f"В очередь попадут только первые {limit} поддерживаемых ссылок."
+
+    @staticmethod
+    def media_caption(title: str) -> str:
+        return f"Медиа: {title}"
+
+    @staticmethod
+    def provider_name(provider: str) -> str:
+        return {
+            "instagram": "Instagram",
+            "twitter": "Twitter/X",
+            "youtube_shorts": "YouTube Shorts",
+        }.get(provider, provider)

--- a/src/instagram_video_bot/services/job_manager.py
+++ b/src/instagram_video_bot/services/job_manager.py
@@ -112,6 +112,7 @@ class JobManager:
                 provider=provider,
                 normalized_url=normalized_url,
                 status=existing.state,
+                joined_existing=True,
             )
             return JobSubmission(
                 job=existing,

--- a/src/instagram_video_bot/services/state_store.py
+++ b/src/instagram_video_bot/services/state_store.py
@@ -63,6 +63,7 @@ class StateStore:
                     normalized_url TEXT NOT NULL,
                     status TEXT NOT NULL,
                     cache_hit INTEGER NOT NULL DEFAULT 0,
+                    joined_existing INTEGER NOT NULL DEFAULT 0,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 );
@@ -72,6 +73,7 @@ class StateStore:
                     quiet_mode INTEGER NOT NULL DEFAULT 0,
                     duplicate_suppression INTEGER NOT NULL DEFAULT 1,
                     stats_enabled INTEGER NOT NULL DEFAULT 1,
+                    chaos_mode_enabled INTEGER NOT NULL DEFAULT 0,
                     chat_max_concurrent_jobs INTEGER,
                     user_max_active_jobs INTEGER
                 );
@@ -107,6 +109,18 @@ class StateStore:
                 self._conn.execute(
                     "ALTER TABLE group_settings ADD COLUMN user_max_active_jobs INTEGER"
                 )
+            if "chaos_mode_enabled" not in existing_columns:
+                self._conn.execute(
+                    "ALTER TABLE group_settings ADD COLUMN chaos_mode_enabled INTEGER NOT NULL DEFAULT 0"
+                )
+            request_columns = {
+                row["name"]
+                for row in self._conn.execute("PRAGMA table_info(request_events)").fetchall()
+            }
+            if "joined_existing" not in request_columns:
+                self._conn.execute(
+                    "ALTER TABLE request_events ADD COLUMN joined_existing INTEGER NOT NULL DEFAULT 0"
+                )
 
     def ensure_group_settings(self, chat_id: int) -> dict[str, Any]:
         with self._lock, self._conn:
@@ -125,7 +139,7 @@ class StateStore:
             )
             row = self._conn.execute(
                 """
-                SELECT quiet_mode, duplicate_suppression, stats_enabled,
+                SELECT quiet_mode, duplicate_suppression, stats_enabled, chaos_mode_enabled,
                        chat_max_concurrent_jobs, user_max_active_jobs
                 FROM group_settings
                 WHERE chat_id = ?
@@ -137,6 +151,7 @@ class StateStore:
             "quiet_mode": bool(row["quiet_mode"]),
             "duplicate_suppression": bool(row["duplicate_suppression"]),
             "stats_enabled": bool(row["stats_enabled"]),
+            "chaos_mode_enabled": bool(row["chaos_mode_enabled"]),
             "chat_max_concurrent_jobs": int(row["chat_max_concurrent_jobs"])
             if row["chat_max_concurrent_jobs"] is not None
             else settings.CHAT_MAX_CONCURRENT_JOBS,
@@ -151,6 +166,7 @@ class StateStore:
             "quiet_mode": "quiet_mode",
             "duplicate_suppression": "duplicate_suppression",
             "stats_enabled": "stats_enabled",
+            "chaos_mode_enabled": "chaos_mode_enabled",
             "chat_max_concurrent_jobs": "chat_max_concurrent_jobs",
             "user_max_active_jobs": "user_max_active_jobs",
         }
@@ -161,7 +177,7 @@ class StateStore:
             if not column:
                 continue
             assignments.append(f"{column} = ?")
-            if key in {"quiet_mode", "duplicate_suppression", "stats_enabled"}:
+            if key in {"quiet_mode", "duplicate_suppression", "stats_enabled", "chaos_mode_enabled"}:
                 values.append(1 if value else 0)
             else:
                 values.append(value)
@@ -222,16 +238,29 @@ class StateStore:
         provider: str,
         normalized_url: str,
         status: str,
+        joined_existing: bool = False,
     ) -> None:
         now = _utc_now().isoformat()
         with self._lock, self._conn:
             self._conn.execute(
                 """
                 INSERT INTO request_events
-                    (request_id, job_id, chat_id, user_id, user_label, provider, normalized_url, status, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (request_id, job_id, chat_id, user_id, user_label, provider, normalized_url, status, joined_existing, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (request_id, job_id, chat_id, user_id, user_label, provider, normalized_url, status, now, now),
+                (
+                    request_id,
+                    job_id,
+                    chat_id,
+                    user_id,
+                    user_label,
+                    provider,
+                    normalized_url,
+                    status,
+                    1 if joined_existing else 0,
+                    now,
+                    now,
+                ),
             )
 
     def update_request_status(self, request_id: str, status: str, cache_hit: bool = False) -> None:
@@ -373,10 +402,20 @@ class StateStore:
                 """,
                 (chat_id,),
             ).fetchall()
+            cache_hits = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM request_events WHERE chat_id = ? AND cache_hit = 1",
+                (chat_id,),
+            ).fetchone()["count"]
+            duplicate_joins = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM request_events WHERE chat_id = ? AND joined_existing = 1",
+                (chat_id,),
+            ).fetchone()["count"]
         return {
             "completed": int(totals["completed"] or 0),
             "failed": int(totals["failed"] or 0),
             "cancelled": int(totals["cancelled"] or 0),
+            "cache_hits": int(cache_hits),
+            "duplicate_joins": int(duplicate_joins),
             "top_users": [(row["user_label"], row["count"]) for row in top_users],
             "top_providers": [(row["provider"], row["count"]) for row in top_providers],
         }

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -22,6 +22,7 @@ from telegram.ext import (
 )
 
 from ..config.settings import settings
+from .chaos_text import ChaosText, TextContext
 from .job_manager import JobManager, SharedJob
 from .request_parser import ParsedRequestLink, RequestParser
 from .state_store import CachedMediaEntry, StateStore
@@ -44,6 +45,7 @@ class RequestContext:
     status_message: Message
     quiet_mode: bool
     joined_existing: bool
+    chaos_enabled: bool = False
 
 
 class TelegramBot:
@@ -80,7 +82,7 @@ class TelegramBot:
         raw_url_count = len(RequestParser.URL_PATTERN.findall(message_text))
         if raw_url_count > settings.MAX_LINKS_PER_MESSAGE:
             await update.message.reply_text(
-                f"Only the first {settings.MAX_LINKS_PER_MESSAGE} supported links will be queued."
+                ChaosText.too_many_links(settings.MAX_LINKS_PER_MESSAGE)
             )
 
         for parsed_link in extracted_links:
@@ -100,6 +102,7 @@ class TelegramBot:
                     parsed_link.provider_label,
                     queue_position=submission.queue_position,
                     joined_existing=not submission.is_new_job,
+                    chaos_enabled=group_settings["chaos_mode_enabled"],
                 )
             )
             request_context = RequestContext(
@@ -113,6 +116,7 @@ class TelegramBot:
                 status_message=status_message,
                 quiet_mode=group_settings["quiet_mode"],
                 joined_existing=not submission.is_new_job,
+                chaos_enabled=group_settings["chaos_mode_enabled"],
             )
             self.request_contexts[submission.request_id] = request_context
             task = asyncio.create_task(self._await_request(context, request_context, submission.job))
@@ -121,26 +125,16 @@ class TelegramBot:
 
     async def help_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Show supported providers and usage help."""
-        if not update.message:
+        if not update.message or not update.effective_chat:
             return
-        await update.message.reply_text(
-            "Send a supported link directly in chat.\n"
-            "Providers: Instagram, Twitter/X, YouTube Shorts.\n"
-            "Commands: /help, /status, /formats, /cancel, /stats\n"
-            "Owner commands: /quiet on|off, /dupes on|off, /statsmode on|off,\n"
-            "/chatlimit <n>, /userlimit <n>, /admin_status"
-        )
+        group_settings = self.state_store.ensure_group_settings(update.effective_chat.id)
+        await update.message.reply_text(ChaosText.help(group_settings["chaos_mode_enabled"]))
 
     async def formats_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Show supported URL shapes."""
         if not update.message:
             return
-        await update.message.reply_text(
-            "Supported formats:\n"
-            "- Instagram posts, reels, stories, and share links\n"
-            "- Twitter/X status links\n"
-            "- YouTube Shorts URLs"
-        )
+        await update.message.reply_text(ChaosText.formats())
 
     async def status_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Show a safe queue and health summary."""
@@ -148,16 +142,9 @@ class TelegramBot:
             return
         snapshot = self.job_manager.get_snapshot(update.effective_chat.id)
         persisted = self.state_store.get_public_status(update.effective_chat.id)
+        group_settings = self.state_store.ensure_group_settings(update.effective_chat.id)
         await update.message.reply_text(
-            "Queue status:\n"
-            f"- Active jobs: {snapshot['active_jobs']}\n"
-            f"- Queued jobs: {snapshot['queued_jobs']}\n"
-            f"- Active requests: {snapshot['active_requests']}\n"
-            f"- Chat concurrency limit: {snapshot['chat_limit']}\n"
-            f"- Per-user limit: {snapshot['user_limit']}\n"
-            f"- Completed requests: {persisted['completed']}\n"
-            f"- Failed requests: {persisted['failed']}\n"
-            f"- Cache hits: {persisted['cache_hits']}"
+            ChaosText.status(snapshot, persisted, chaos_enabled=group_settings["chaos_mode_enabled"])
         )
 
     async def cancel_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -169,7 +156,7 @@ class TelegramBot:
             update.effective_user.id,
         )
         if not request_id:
-            await update.message.reply_text("You have no active queued or running requests.")
+            await update.message.reply_text(ChaosText.no_active_request())
             return
 
         task = self.active_request_tasks.get(request_id)
@@ -178,9 +165,12 @@ class TelegramBot:
         job = self.job_manager.cancel_request(request_id)
         request_context = self.request_contexts.get(request_id)
         if request_context:
-            await self._safe_edit_text(request_context.status_message, "🛑 Request cancelled.")
+            await self._safe_edit_text(
+                request_context.status_message,
+                ChaosText.cancelled(request_context.chaos_enabled),
+            )
         if job and update.message:
-            await update.message.reply_text("Latest request cancelled.")
+            await update.message.reply_text(ChaosText.latest_cancelled())
 
     async def stats_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Show lightweight group stats."""
@@ -188,22 +178,36 @@ class TelegramBot:
             return
         group_settings = self.state_store.ensure_group_settings(update.effective_chat.id)
         if not group_settings["stats_enabled"]:
-            await update.message.reply_text("Stats are disabled for this chat.")
+            await update.message.reply_text(ChaosText.stats_disabled())
             return
 
         stats = self.state_store.get_group_stats(update.effective_chat.id)
-        top_users = ", ".join(f"{name} ({count})" for name, count in stats["top_users"]) or "No completed requests yet"
-        top_providers = ", ".join(
-            f"{provider} ({count})" for provider, count in stats["top_providers"]
-        ) or "No completed requests yet"
         await update.message.reply_text(
-            "Group stats:\n"
-            f"- Completed: {stats['completed']}\n"
-            f"- Failed: {stats['failed']}\n"
-            f"- Cancelled: {stats['cancelled']}\n"
-            f"- Top users: {top_users}\n"
-            f"- Top providers: {top_providers}"
+            ChaosText.stats(stats, chaos_enabled=group_settings["chaos_mode_enabled"])
         )
+
+    async def chaos_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Toggle or inspect chat-level chaos mode."""
+        if not update.message or not update.effective_chat or not update.effective_user:
+            return
+        action = (context.args[0] if context.args else "status").strip().lower()
+        if action == "status":
+            settings_row = self.state_store.ensure_group_settings(update.effective_chat.id)
+            await update.message.reply_text(ChaosText.chaos_status(settings_row["chaos_mode_enabled"]))
+            return
+
+        desired = self._parse_toggle_arg(action)
+        if desired is None:
+            await update.message.reply_text(ChaosText.chaos_usage())
+            return
+        if not await self._require_chaos_admin(update, context):
+            return
+
+        result = self.state_store.update_group_settings(
+            update.effective_chat.id,
+            chaos_mode_enabled=desired,
+        )
+        await update.message.reply_text(ChaosText.chaos_updated(result["chaos_mode_enabled"]))
 
     async def quiet_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Toggle quiet mode for the current chat. Owner-only."""
@@ -212,7 +216,7 @@ class TelegramBot:
             context,
             setting_name="quiet_mode",
             command_name="quiet",
-            label="Quiet mode",
+            label="Тихий режим",
         )
 
     async def dupes_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -222,7 +226,7 @@ class TelegramBot:
             context,
             setting_name="duplicate_suppression",
             command_name="dupes",
-            label="Duplicate suppression",
+            label="Защита от повторов",
         )
 
     async def statsmode_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -232,7 +236,7 @@ class TelegramBot:
             context,
             setting_name="stats_enabled",
             command_name="statsmode",
-            label="Stats mode",
+            label="Статистика",
         )
 
     async def chatlimit_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -242,7 +246,7 @@ class TelegramBot:
             context,
             setting_name="chat_max_concurrent_jobs",
             command_name="chatlimit",
-            label="Chat concurrency limit",
+            label="Лимит чата",
         )
 
     async def userlimit_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -252,7 +256,7 @@ class TelegramBot:
             context,
             setting_name="user_max_active_jobs",
             command_name="userlimit",
-            label="Per-user limit",
+            label="Лимит на пользователя",
         )
 
     async def admin_status_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -267,29 +271,30 @@ class TelegramBot:
         provider_lines = ", ".join(
             f"{provider}:{status}={count}"
             for provider, status, count in admin_status["provider_job_counts"]
-        ) or "none"
+        ) or "нет"
         failure_lines = "\n".join(
             f"  - {provider} | {error_class} | {normalized_url}"
             for provider, normalized_url, error_class, _finished_at in admin_status["recent_failures"]
-        ) or "  - none"
+        ) or "  - нет"
         uptime_seconds = int(time.time() - self.started_at)
         await update.message.reply_text(
-            "Admin status:\n"
-            f"- Uptime: {uptime_seconds}s\n"
-            f"- Quiet mode: {'on' if settings_row['quiet_mode'] else 'off'}\n"
-            f"- Duplicate suppression: {'on' if settings_row['duplicate_suppression'] else 'off'}\n"
-            f"- Stats mode: {'on' if settings_row['stats_enabled'] else 'off'}\n"
-            f"- Chat concurrency limit: {settings_row['chat_max_concurrent_jobs']}\n"
-            f"- Per-user limit: {settings_row['user_max_active_jobs']}\n"
-            f"- Running jobs: {admin_status['running_jobs']}\n"
-            f"- Queued jobs: {admin_status['queued_jobs']}\n"
-            f"- Active requests: {snapshot['active_requests']}\n"
-            f"- Failed jobs: {admin_status['failed_jobs']}\n"
-            f"- Cache entries: {admin_status['cache_entries']}\n"
-            f"- Result cache enabled: {'on' if settings.RESULT_CACHE_ENABLED else 'off'}\n"
-            f"- Queue manager enabled: {'on' if settings.QUEUE_MANAGER_ENABLED else 'off'}\n"
-            f"- Provider job counts: {provider_lines}\n"
-            f"- Recent failures:\n{failure_lines}"
+            "Админ-статус:\n"
+            f"- Аптайм: {uptime_seconds}с\n"
+            f"- Тихий режим: {self._ru_on_off(settings_row['quiet_mode'])}\n"
+            f"- Защита от повторов: {self._ru_on_off(settings_row['duplicate_suppression'], feminine=True)}\n"
+            f"- Статистика: {self._ru_on_off(settings_row['stats_enabled'], feminine=True)}\n"
+            f"- Режим хаоса: {self._ru_on_off(settings_row['chaos_mode_enabled'])}\n"
+            f"- Лимит чата: {settings_row['chat_max_concurrent_jobs']}\n"
+            f"- Лимит на пользователя: {settings_row['user_max_active_jobs']}\n"
+            f"- Выполняется задач: {admin_status['running_jobs']}\n"
+            f"- В очереди задач: {admin_status['queued_jobs']}\n"
+            f"- Активные запросы: {snapshot['active_requests']}\n"
+            f"- Ошибочных задач: {admin_status['failed_jobs']}\n"
+            f"- Записей в кэше: {admin_status['cache_entries']}\n"
+            f"- Кэш результатов: {self._ru_on_off(settings.RESULT_CACHE_ENABLED)}\n"
+            f"- Менеджер очереди: {self._ru_on_off(settings.QUEUE_MANAGER_ENABLED)}\n"
+            f"- Задачи по площадкам: {provider_lines}\n"
+            f"- Последние ошибки:\n{failure_lines}"
         )
 
     async def _await_request(
@@ -349,7 +354,10 @@ class TelegramBot:
             self.job_manager.mark_request_failed(request_context.request_id, status="cancelled")
             raise
         except VideoDownloadError as error:
-            error_message = self._build_error_message(error)
+            error_message = self._build_error_message(
+                error,
+                chaos_enabled=request_context.chaos_enabled,
+            )
             logger.error("Download error for %s: %s", request_context.original_url, error)
             if self.job_manager.is_delivery_request(job, request_context.request_id):
                 self.job_manager.mark_delivery_failed(job, request_context.request_id, error)
@@ -361,7 +369,7 @@ class TelegramBot:
                 self.job_manager.mark_delivery_failed(job, request_context.request_id, error)
             await self._safe_edit_text(
                 request_context.status_message,
-                "❌ An unexpected error occurred. Please try again later."
+                ChaosText.unexpected_error()
             )
             self.job_manager.mark_request_failed(request_context.request_id, status="failed")
 
@@ -420,13 +428,18 @@ class TelegramBot:
             if job.state == "running":
                 if request_context.quiet_mode or request_context.joined_existing:
                     continue
-                text = f"⬇️ {request_context.provider_label} downloading..."
+                text = ChaosText.running(
+                    TextContext(
+                        provider_label=request_context.provider_label,
+                        chaos_enabled=request_context.chaos_enabled,
+                    )
+                )
                 await self._edit_status_message(request_context.status_message, text)
             elif job.state == "cancelled":
-                text = "🛑 Request cancelled."
+                text = ChaosText.cancelled(request_context.chaos_enabled)
                 await self._safe_edit_text(request_context.status_message, text)
             else:
-                text = "❌ Download failed."
+                text = ChaosText.failed(request_context.chaos_enabled)
                 await self._safe_edit_text(request_context.status_message, text)
 
     async def _global_error_handler(
@@ -550,13 +563,13 @@ class TelegramBot:
         *,
         queue_position: int,
         joined_existing: bool = False,
+        chaos_enabled: bool = False,
     ) -> str:
-        if joined_existing:
-            return f"🔁 {provider_label} already in progress. Waiting for the shared result."
-        if queue_position > 1:
-            ahead = queue_position - 1
-            return f"🕓 {provider_label} queued. {ahead} ahead of you."
-        return f"🕓 {provider_label} accepted. Starting shortly."
+        return ChaosText.submission(
+            TextContext(provider_label=provider_label, chaos_enabled=chaos_enabled),
+            queue_position=queue_position,
+            joined_existing=joined_existing,
+        )
 
     @classmethod
     def _build_caption_text(cls, title: str) -> str:
@@ -564,26 +577,14 @@ class TelegramBot:
         caption = title.strip()
         if not caption:
             return ""
-        full_caption = f"📹 {caption}"
+        full_caption = ChaosText.media_caption(caption)
         if len(full_caption) <= cls.MAX_MEDIA_CAPTION_LENGTH:
             return full_caption
         return full_caption[: cls.MAX_MEDIA_CAPTION_LENGTH - 3].rstrip() + "..."
 
     @staticmethod
-    def _build_error_message(error: Exception) -> str:
-        error_str = str(error).lower()
-        if "authentication failed" in error_str or "cookies have expired" in error_str:
-            return (
-                "🔐 Instagram authentication failed. "
-                "The bot owner needs to refresh the session."
-            )
-        if "rate-limit" in error_str or "rate limit" in error_str:
-            return "⏳ Provider rate limit reached. Please try again later."
-        if "unsupported" in error_str:
-            return f"❌ {str(error)}"
-        if "timed out" in error_str:
-            return "⏱️ Download timed out. Please try again."
-        return f"❌ Sorry, couldn't download the media: {str(error)}"
+    def _build_error_message(error: Exception, *, chaos_enabled: bool = False) -> str:
+        return ChaosText.error(error, chaos_enabled=chaos_enabled)
 
     @staticmethod
     async def _edit_status_message(message: Message, text: str) -> None:
@@ -639,11 +640,10 @@ class TelegramBot:
             return
         desired = self._parse_toggle_arg(context.args[0] if context.args else "")
         if desired is None:
-            await update.message.reply_text(f"Usage: /{command_name} on|off")
+            await update.message.reply_text(ChaosText.setting_usage(command_name))
             return
         result = self.state_store.update_group_settings(update.effective_chat.id, **{setting_name: desired})
-        state = "enabled" if result[setting_name] else "disabled"
-        await update.message.reply_text(f"{label} {state}.")
+        await update.message.reply_text(ChaosText.setting_updated(label, result[setting_name]))
 
     async def _set_numeric_group_setting(
         self,
@@ -661,28 +661,57 @@ class TelegramBot:
             return
         value = self._parse_positive_int_arg(context.args[0] if context.args else "")
         if value is None:
-            await update.message.reply_text(f"Usage: /{command_name} <positive integer>")
+            await update.message.reply_text(ChaosText.numeric_setting_usage(command_name))
             return
         result = self.state_store.update_group_settings(update.effective_chat.id, **{setting_name: value})
         if setting_name == "chat_max_concurrent_jobs":
             self.job_manager.update_chat_limits(update.effective_chat.id, chat_limit=value)
         elif setting_name == "user_max_active_jobs":
             self.job_manager.update_chat_limits(update.effective_chat.id, user_limit=value)
-        await update.message.reply_text(f"{label} set to {result[setting_name]}.")
+        await update.message.reply_text(ChaosText.numeric_setting_updated(label, result[setting_name]))
+
+    @staticmethod
+    def _ru_on_off(value: bool, *, feminine: bool = False) -> str:
+        if feminine:
+            return "включена" if value else "выключена"
+        return "включен" if value else "выключен"
 
     async def _require_owner(self, update: Update) -> bool:
         """Return whether the sender is the configured bot owner."""
         if not update.message or not update.effective_user:
             return False
         if settings.BOT_OWNER_USER_ID is None:
-            await update.message.reply_text(
-                "Owner-only commands are unavailable until BOT_OWNER_USER_ID is configured."
-            )
+            await update.message.reply_text(ChaosText.owner_unconfigured())
             return False
         if update.effective_user.id != settings.BOT_OWNER_USER_ID:
-            await update.message.reply_text("This command is only available to the bot owner.")
+            await update.message.reply_text(ChaosText.owner_required())
             return False
         return True
+
+    async def _require_chaos_admin(
+        self,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> bool:
+        """Return whether the sender can manage chat-level chaos mode."""
+        if not update.message or not update.effective_chat or not update.effective_user:
+            return False
+        if getattr(update.effective_chat, "type", "") == "private":
+            return True
+        if settings.BOT_OWNER_USER_ID is not None and update.effective_user.id == settings.BOT_OWNER_USER_ID:
+            return True
+        try:
+            member = await context.bot.get_chat_member(
+                update.effective_chat.id,
+                update.effective_user.id,
+            )
+        except Exception:
+            await update.message.reply_text(ChaosText.admin_required())
+            return False
+        if getattr(member, "status", "") in {"administrator", "creator"}:
+            return True
+        await update.message.reply_text(ChaosText.admin_required())
+        return False
 
     @staticmethod
     def _parse_toggle_arg(value: str) -> bool | None:
@@ -723,6 +752,7 @@ class TelegramBot:
         self.application.add_handler(CommandHandler("formats", self.formats_command))
         self.application.add_handler(CommandHandler("cancel", self.cancel_command))
         self.application.add_handler(CommandHandler("stats", self.stats_command))
+        self.application.add_handler(CommandHandler("chaos", self.chaos_command))
         self.application.add_handler(CommandHandler("quiet", self.quiet_command))
         self.application.add_handler(CommandHandler("dupes", self.dupes_command))
         self.application.add_handler(CommandHandler("statsmode", self.statsmode_command))

--- a/test_proxies.py
+++ b/test_proxies.py
@@ -6,7 +6,11 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent / 'src'))
 
-from src.instagram_video_bot.utils.proxy_manager import proxy_manager, test_all_proxies, get_proxy_for_account
+from src.instagram_video_bot.utils.proxy_manager import (
+    get_proxy_for_account,
+    proxy_manager,
+    test_all_proxies as run_all_proxy_checks,
+)
 
 def main():
     """Test all proxies and show account assignments."""
@@ -40,7 +44,7 @@ def main():
     
     # Test all proxies
     print("🔍 Testing proxy connectivity...")
-    results = test_all_proxies()
+    results = run_all_proxy_checks()
     
     working_count = 0
     for i, (proxy, is_working) in enumerate(results, 1):
@@ -84,4 +88,4 @@ def main():
     print("- Use residential proxies for best results")
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/tests/test_chaos_text.py
+++ b/tests/test_chaos_text.py
@@ -37,3 +37,35 @@ def test_error_text_is_russian_for_rate_limit():
     text = ChaosText.error(RuntimeError("rate limit"), chaos_enabled=False)
 
     assert "лимит" in text.lower()
+
+
+def test_error_text_does_not_expose_raw_provider_stderr():
+    text = ChaosText.error(
+        RuntimeError("Twitter/X download failed: token=secret https://x.com/a/status/1"),
+        chaos_enabled=False,
+    )
+
+    assert text == "Не смог скачать медиа. Попробуй позже."
+    assert "secret" not in text
+    assert "https://x.com" not in text
+
+
+def test_chaos_error_text_does_not_expose_raw_provider_stderr():
+    text = ChaosText.error(
+        RuntimeError("Download failed: proxy=http://user:pass@example.com:8080"),
+        chaos_enabled=True,
+    )
+
+    assert text == "Не смог скачать медиа. Попробуй позже."
+    assert "user:pass" not in text
+    assert "proxy" not in text
+
+
+def test_unsupported_error_text_does_not_echo_raw_exception():
+    text = ChaosText.error(
+        RuntimeError("Unsupported Twitter/X URL https://x.com/not/status"),
+        chaos_enabled=False,
+    )
+
+    assert text == "Эта ссылка не поддерживается."
+    assert "https://x.com" not in text

--- a/tests/test_chaos_text.py
+++ b/tests/test_chaos_text.py
@@ -1,0 +1,39 @@
+from src.instagram_video_bot.services.chaos_text import ChaosText, TextContext
+
+
+def test_normal_submission_text_is_russian():
+    text = ChaosText.submission(
+        TextContext(provider_label="Instagram", chaos_enabled=False),
+        queue_position=1,
+        joined_existing=False,
+    )
+
+    assert text == "Принял Instagram. Скоро начну скачивать."
+
+
+def test_chaos_submission_text_is_russian_and_provider_aware():
+    text = ChaosText.submission(
+        TextContext(provider_label="Twitter/X", chaos_enabled=True),
+        queue_position=1,
+        joined_existing=False,
+    )
+
+    assert "Twitter/X" in text
+    assert "шум" in text.lower()
+
+
+def test_chaos_duplicate_text_is_russian():
+    text = ChaosText.submission(
+        TextContext(provider_label="Instagram", chaos_enabled=True),
+        queue_position=1,
+        joined_existing=True,
+    )
+
+    assert "уже" in text.lower()
+    assert "Instagram" in text
+
+
+def test_error_text_is_russian_for_rate_limit():
+    text = ChaosText.error(RuntimeError("rate limit"), chaos_enabled=False)
+
+    assert "лимит" in text.lower()

--- a/tests/test_state_store_chaos.py
+++ b/tests/test_state_store_chaos.py
@@ -1,0 +1,53 @@
+from src.instagram_video_bot.services.state_store import StateStore
+
+
+def test_group_settings_include_disabled_chaos_mode_by_default(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+
+    settings = store.ensure_group_settings(77)
+
+    assert settings["chaos_mode_enabled"] is False
+
+
+def test_group_settings_can_enable_chaos_mode(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+
+    settings = store.update_group_settings(77, chaos_mode_enabled=True)
+
+    assert settings["chaos_mode_enabled"] is True
+    assert store.ensure_group_settings(77)["chaos_mode_enabled"] is True
+
+
+def test_group_stats_include_cache_hits_duplicate_joins_and_provider_counts(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    store.create_job("job-1", 77, "https://x.com/a/status/1", "twitter", "queued")
+    store.create_request(
+        "req-1",
+        "job-1",
+        77,
+        1001,
+        "@alice",
+        "twitter",
+        "https://x.com/a/status/1",
+        "queued",
+    )
+    store.create_request(
+        "req-2",
+        "job-1",
+        77,
+        1002,
+        "@bob",
+        "twitter",
+        "https://x.com/a/status/1",
+        "queued",
+        joined_existing=True,
+    )
+    store.update_request_status("req-1", "completed", cache_hit=True)
+    store.update_request_status("req-2", "completed")
+
+    stats = store.get_group_stats(77)
+
+    assert stats["completed"] == 2
+    assert stats["cache_hits"] == 1
+    assert stats["duplicate_joins"] == 1
+    assert stats["top_providers"] == [("twitter", 2)]

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -11,10 +11,11 @@ from src.instagram_video_bot.services.video_downloader import MediaItem, VideoIn
 
 
 class _FakeBot:
-    def __init__(self):
+    def __init__(self, member_status: str = "member"):
         self.video_calls = []
         self.photo_calls = []
         self.group_calls = []
+        self.member_status = member_status
 
     async def send_video(self, **kwargs):
         self.video_calls.append(kwargs)
@@ -24,6 +25,9 @@ class _FakeBot:
 
     async def send_media_group(self, **kwargs):
         self.group_calls.append(kwargs)
+
+    async def get_chat_member(self, chat_id: int, user_id: int):
+        return SimpleNamespace(status=self.member_status)
 
 
 class _FakeStatusMessage:
@@ -66,9 +70,10 @@ class _FakeUpdate:
         username: str = "alice",
         full_name: str = "Alice",
         message_id: int = 10,
+        chat_type: str = "private",
     ):
         self.message = _FakeMessage(text, message_id=message_id)
-        self.effective_chat = SimpleNamespace(id=chat_id)
+        self.effective_chat = SimpleNamespace(id=chat_id, type=chat_type)
         self.effective_user = SimpleNamespace(id=user_id, username=username, full_name=full_name)
 
 
@@ -198,8 +203,8 @@ async def test_handle_message_processes_request_in_background(monkeypatch, tmp_p
 
     assert not media_file.exists()
     assert len(fake_bot.video_calls) == 1
-    assert update.message.replies == ["🕓 Instagram accepted. Starting shortly."]
-    assert update.message.status_messages[0].texts == ["⬇️ Instagram downloading..."]
+    assert update.message.replies == ["Принял Instagram. Скоро начну скачивать."]
+    assert update.message.status_messages[0].texts == ["Instagram: скачиваю."]
     assert update.message.status_messages[0].deleted is True
 
 
@@ -234,8 +239,95 @@ async def test_duplicate_suppressed_requests_send_media_only_once(monkeypatch, t
     assert fake_bot.video_calls[0]["reply_to_message_id"] == 10
     assert first_update.message.status_messages[0].deleted is True
     assert second_update.message.status_messages[0].deleted is True
-    assert second_update.message.replies == ["🔁 Instagram already in progress. Waiting for the shared result."]
+    assert second_update.message.replies == ["Instagram уже скачивается. Дождусь общего результата."]
     assert second_update.message.status_messages[0].texts == []
+
+
+@pytest.mark.asyncio
+async def test_chaos_duplicate_request_uses_playful_russian_text(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    telegram_bot.state_store.update_group_settings(77, chaos_mode_enabled=True)
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    first_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1001, username="alice", full_name="Alice", message_id=10)
+    second_update = _FakeUpdate("https://www.instagram.com/reel/a/", user_id=1002, username="bob", full_name="Bob", message_id=11)
+
+    media_file = tmp_path / "shared-chaos.mp4"
+    media_file.write_bytes(b"video")
+
+    async def fake_download_video(self, url: str, output_dir: Path):
+        await asyncio.sleep(0)
+        return VideoInfo(
+            file_path=media_file,
+            title="shared",
+            media_items=[MediaItem(file_path=media_file, media_type="video")],
+            primary_media_type="video",
+        )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.RESULT_CACHE_ENABLED", False)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader.download_video", fake_download_video)
+
+    await telegram_bot.handle_message(first_update, context)
+    await telegram_bot.handle_message(second_update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert len(fake_bot.video_calls) == 1
+    assert second_update.message.replies == ["Instagram уже в работе. Повтор засчитан, сидим рядом с таймером."]
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_is_delivered_and_counted(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    update = _FakeUpdate("https://www.instagram.com/reel/cached/")
+    media_file = tmp_path / "cached.mp4"
+    media_file.write_bytes(b"video")
+    telegram_bot.state_store.save_cached_result(
+        chat_id=77,
+        normalized_url="https://www.instagram.com/reel/cached/",
+        provider="instagram",
+        title="cached",
+        media_items=[
+            {
+                "file_path": str(media_file),
+                "media_type": "video",
+                "caption": None,
+                "duration": None,
+            }
+        ],
+        ttl_seconds=3600,
+    )
+
+    async def fail_download_video(self, url: str, output_dir: Path):
+        raise AssertionError("cache hit should skip downloader")
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader.download_video", fail_download_video)
+
+    await telegram_bot.handle_message(update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert len(fake_bot.video_calls) == 1
+    assert telegram_bot.state_store.get_public_status(77)["cache_hits"] == 1
+
+
+@pytest.mark.asyncio
+async def test_download_failure_uses_russian_error_text(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    context = _FakeContext(_FakeBot())
+    update = _FakeUpdate("https://www.instagram.com/reel/fail/")
+
+    async def fail_download_video(self, url: str, output_dir: Path):
+        from src.instagram_video_bot.services.video_downloader import DownloadError
+
+        raise DownloadError("rate limit")
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader.download_video", fail_download_video)
+
+    await telegram_bot.handle_message(update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert update.message.status_messages[0].texts[-1] == "Достигнут лимит провайдера. Попробуй позже."
 
 
 @pytest.mark.parametrize(
@@ -304,7 +396,7 @@ async def test_shared_delivery_handoffs_to_another_requester_on_send_failure(mon
     assert delivered_message_ids == [11]
     assert first_update.message.status_messages[0].deleted is True
     assert second_update.message.status_messages[0].deleted is True
-    assert first_update.message.status_messages[0].texts == ["⬇️ Instagram downloading..."]
+    assert first_update.message.status_messages[0].texts == ["Instagram: скачиваю."]
     assert second_update.message.status_messages[0].texts == []
 
 
@@ -318,7 +410,7 @@ async def test_owner_only_quiet_command_requires_owner(monkeypatch, tmp_path):
 
     await telegram_bot.quiet_command(update, context)
 
-    assert update.message.replies[-1] == "This command is only available to the bot owner."
+    assert update.message.replies[-1] == "Эта команда доступна только владельцу бота."
 
 
 @pytest.mark.asyncio
@@ -333,7 +425,70 @@ async def test_owner_can_toggle_quiet_mode(monkeypatch, tmp_path):
 
     settings_row = telegram_bot.state_store.ensure_group_settings(update.effective_chat.id)
     assert settings_row["quiet_mode"] is True
-    assert update.message.replies[-1] == "Quiet mode enabled."
+    assert update.message.replies[-1] == "Тихий режим: включено."
+
+
+@pytest.mark.asyncio
+async def test_owner_can_toggle_chaos_mode_on_and_off(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    context = _FakeContext(_FakeBot(), args=["on"])
+    update = _FakeUpdate("/chaos on", chat_type="group")
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+
+    await telegram_bot.chaos_command(update, context)
+
+    settings_row = telegram_bot.state_store.ensure_group_settings(update.effective_chat.id)
+    assert settings_row["chaos_mode_enabled"] is True
+    assert update.message.replies[-1] == "Режим хаоса включен. Теперь бот будет шуметь по делу."
+
+    context.args = ["off"]
+    await telegram_bot.chaos_command(update, context)
+
+    settings_row = telegram_bot.state_store.ensure_group_settings(update.effective_chat.id)
+    assert settings_row["chaos_mode_enabled"] is False
+    assert update.message.replies[-1] == "Режим хаоса выключен. Возвращаюсь к спокойному режиму."
+
+
+@pytest.mark.asyncio
+async def test_chaos_status_reports_russian_state(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/chaos status")
+    context = _FakeContext(_FakeBot(), args=["status"])
+
+    await telegram_bot.chaos_command(update, context)
+
+    assert update.message.replies[-1] == "Режим хаоса выключен для этого чата."
+
+
+@pytest.mark.asyncio
+async def test_chaos_command_rejects_non_admin_group_member(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/chaos on", chat_type="group")
+    context = _FakeContext(_FakeBot(member_status="member"), args=["on"])
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 9999)
+
+    await telegram_bot.chaos_command(update, context)
+
+    assert update.message.replies[-1] == "Режим хаоса могут переключать только админы чата или владелец бота."
+
+
+@pytest.mark.asyncio
+async def test_help_formats_status_and_stats_are_russian(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/help")
+    context = _FakeContext(_FakeBot())
+
+    await telegram_bot.help_command(update, context)
+    await telegram_bot.formats_command(update, context)
+    await telegram_bot.status_command(update, context)
+    await telegram_bot.stats_command(update, context)
+
+    assert "Пришли ссылку" in update.message.replies[0]
+    assert "Поддерживаемые ссылки" in update.message.replies[1]
+    assert "Статус очереди" in update.message.replies[2]
+    assert "Статистика чата" in update.message.replies[3]
 
 
 @pytest.mark.asyncio
@@ -416,7 +571,7 @@ async def test_owner_can_toggle_stats_mode(monkeypatch, tmp_path):
 
     settings_row = telegram_bot.state_store.ensure_group_settings(update.effective_chat.id)
     assert settings_row["stats_enabled"] is False
-    assert update.message.replies[-1] == "Stats mode disabled."
+    assert update.message.replies[-1] == "Статистика: выключено."
 
 
 @pytest.mark.asyncio
@@ -433,7 +588,7 @@ async def test_owner_can_override_chat_limit(monkeypatch, tmp_path):
     snapshot = telegram_bot.job_manager.get_snapshot(update.effective_chat.id)
     assert settings_row["chat_max_concurrent_jobs"] == 4
     assert snapshot["chat_limit"] == 4
-    assert update.message.replies[-1] == "Chat concurrency limit set to 4."
+    assert update.message.replies[-1] == "Лимит чата: 4."
 
 
 @pytest.mark.asyncio
@@ -455,8 +610,8 @@ async def test_admin_status_reports_owner_settings(monkeypatch, tmp_path):
     await telegram_bot.admin_status_command(update, context)
 
     reply = update.message.replies[-1]
-    assert "Quiet mode: on" in reply
-    assert "Duplicate suppression: off" in reply
-    assert "Stats mode: off" in reply
-    assert "Chat concurrency limit: 5" in reply
-    assert "Per-user limit: 2" in reply
+    assert "Тихий режим: включен" in reply
+    assert "Защита от повторов: выключена" in reply
+    assert "Статистика: выключена" in reply
+    assert "Лимит чата: 5" in reply
+    assert "Лимит на пользователя: 2" in reply


### PR DESCRIPTION
## Summary
- Add per-chat Russian Chaos Mode with `/chaos on|off|status` and group admin or owner control.
- Centralize Russian user-facing bot text for commands, lifecycle status, errors, duplicate/cache moments, and stats.
- Persist chaos settings and duplicate-join stats without changing downloader execution.
- Stop pytest from collecting the proxy helper script function as a test.

## Test Plan
- `uv run pytest -q` (`83 passed`)
