### PR TITLE
Add account auto-quarantine and owner alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Telegram Bot Configuration
 BOT_TOKEN=your_telegram_bot_token_here
+# Telegram user ID that receives owner-only alerts and can use owner commands.
+BOT_OWNER_USER_ID=
 
 # Account health automation
 # Account is removed from usable rotation after this many sequential auth/download failures.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
 # Telegram Bot Configuration
 BOT_TOKEN=your_telegram_bot_token_here
 
+# Account health automation
+# Account is removed from usable rotation after this many sequential auth/download failures.
+ACCOUNT_FAILURE_THRESHOLD=2
+# Notify BOT_OWNER_USER_ID when usable Instagram accounts drop below this number.
+ACCOUNT_LOW_WATERMARK=3
+# Minimum seconds between low-account-pool DM alerts.
+ACCOUNT_ALERT_COOLDOWN_SECONDS=3600
+
 # Instagram Credentials
 IG_USERNAME=your_instagram_username
 IG_PASSWORD=your_instagram_password

--- a/README.md
+++ b/README.md
@@ -317,6 +317,15 @@ username2|password2|totp_secret2
 
 Every managed account needs a password and a non-empty `totp_secret`. Empty third fields stay unavailable and will not be used for rotation.
 
+### Account Auto-Quarantine
+
+The bot tracks sequential failures for each managed Instagram account in `accounts_state.json`.
+When an account reaches `ACCOUNT_FAILURE_THRESHOLD` sequential auth/download failures, it is removed from the usable rotation by state, not deleted from `accounts.txt`.
+A successful account use resets its sequential failure counter.
+
+If usable accounts drop below `ACCOUNT_LOW_WATERMARK`, the bot sends an English DM alert to `BOT_OWNER_USER_ID`.
+Alerts are rate-limited by `ACCOUNT_ALERT_COOLDOWN_SECONDS` to avoid spam during outage bursts.
+
 Initialize sessions after creating `accounts.txt`:
 ```bash
 uv run python manage_accounts.py setup

--- a/src/instagram_video_bot/config/settings.py
+++ b/src/instagram_video_bot/config/settings.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
     # Bot settings
     BOT_TOKEN: str = ""
     BOT_OWNER_USER_ID: Optional[int] = None
+    ACCOUNT_FAILURE_THRESHOLD: int = 2
+    ACCOUNT_LOW_WATERMARK: int = 3
+    ACCOUNT_ALERT_COOLDOWN_SECONDS: int = 60 * 60
     
     # Instagram credentials
     IG_USERNAME: str = ""

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -426,6 +426,10 @@ class TelegramBot:
                     ],
                     ttl_seconds=settings.RECENT_RESULT_TTL_SECONDS,
                 )
+            await self._notify_owner_about_low_account_pool(
+                context,
+                getattr(downloader, "last_account_health_event", None),
+            )
             return video_info
 
         return _execute

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -94,7 +94,7 @@ class TelegramBot:
                 provider_label=parsed_link.provider_label,
                 original_url=parsed_link.original_url,
                 normalized_url=parsed_link.normalized_url,
-                execute=self._build_job_executor(update.effective_chat.id, parsed_link),
+                execute=self._build_job_executor(update.effective_chat.id, parsed_link, context),
                 duplicate_suppression=group_settings["duplicate_suppression"],
             )
             status_message = await update.message.reply_text(
@@ -373,7 +373,12 @@ class TelegramBot:
             )
             self.job_manager.mark_request_failed(request_context.request_id, status="failed")
 
-    def _build_job_executor(self, chat_id: int, parsed_link: ParsedRequestLink):
+    def _build_job_executor(
+        self,
+        chat_id: int,
+        parsed_link: ParsedRequestLink,
+        context: ContextTypes.DEFAULT_TYPE,
+    ):
         """Create the underlying shared job executor closure."""
 
         async def _execute() -> VideoInfo:
@@ -396,7 +401,14 @@ class TelegramBot:
                 else settings.TEMP_DIR / parsed_link.provider
             )
             output_dir.mkdir(parents=True, exist_ok=True)
-            video_info = await downloader.download_video(parsed_link.original_url, output_dir)
+            try:
+                video_info = await downloader.download_video(parsed_link.original_url, output_dir)
+            except Exception:
+                await self._notify_owner_about_low_account_pool(
+                    context,
+                    getattr(downloader, "last_account_health_event", None),
+                )
+                raise
             if settings.RESULT_CACHE_ENABLED:
                 self.state_store.save_cached_result(
                     chat_id=chat_id,

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -732,6 +732,28 @@ class TelegramBot:
             return None
         return parsed
 
+    async def _notify_owner_about_low_account_pool(self, context, event) -> None:
+        if event is None or not event.should_alert_owner:
+            return
+        if settings.BOT_OWNER_USER_ID is None:
+            logger.warning("Skipping low account pool owner alert: BOT_OWNER_USER_ID is not configured")
+            return
+        if not getattr(context, "bot", None):
+            logger.warning("Skipping low account pool owner alert: Telegram bot context is unavailable")
+            return
+
+        text = (
+            "Instagram account pool warning:\n"
+            f"Usable accounts left: {event.available_accounts} of {event.total_accounts}.\n"
+            f"Low-watermark threshold: {event.low_watermark}.\n"
+            f"Last removed account: {event.username}.\n"
+            f"Reason: {event.reason} after {event.consecutive_failures} sequential failures."
+        )
+        try:
+            await context.bot.send_message(chat_id=settings.BOT_OWNER_USER_ID, text=text)
+        except TelegramError as exc:
+            logger.warning("Failed to send low account pool owner alert: %s", exc)
+
     def _cleanup_request_task(self, request_id: str) -> None:
         self.active_request_tasks.pop(request_id, None)
         self.request_contexts.pop(request_id, None)

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -51,6 +51,7 @@ class VideoDownloader:
         self.youtube_adapter = YouTubeShortsProviderAdapter(
             YouTubeShortsDownloader()
         )
+        self.last_account_health_event = None
 
     @property
     def fast_extractor(self):
@@ -184,6 +185,7 @@ class VideoDownloader:
                     redact_proxy=self._redact_proxy,
                 )
                 manager.record_account_success(account)
+                self.last_account_health_event = None
                 return result
             except (InstagramAuthError, AuthenticationError) as auth_error:
                 last_error = auth_error
@@ -196,7 +198,7 @@ class VideoDownloader:
                         "error": str(auth_error),
                     },
                 )
-                manager.record_account_failure(account, "auth_challenge")
+                self.last_account_health_event = manager.record_account_failure(account, "auth_challenge")
             except Exception as error:
                 if isinstance(error, DownloadError):
                     raise

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -198,7 +198,9 @@ class VideoDownloader:
                         "error": str(auth_error),
                     },
                 )
-                self.last_account_health_event = manager.record_account_failure(account, "auth_challenge")
+                event = manager.record_account_failure(account, "auth_challenge")
+                if getattr(event, "should_alert_owner", False) or self.last_account_health_event is None:
+                    self.last_account_health_event = event
             except Exception as error:
                 if isinstance(error, DownloadError):
                     raise

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -185,7 +185,8 @@ class VideoDownloader:
                     redact_proxy=self._redact_proxy,
                 )
                 manager.record_account_success(account)
-                self.last_account_health_event = None
+                if not getattr(self.last_account_health_event, "should_alert_owner", False):
+                    self.last_account_health_event = None
                 return result
             except (InstagramAuthError, AuthenticationError) as auth_error:
                 last_error = auth_error

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -171,9 +171,6 @@ class VideoDownloader:
             account = manager.acquire_account(excluded_usernames=tried_accounts)
             if not account:
                 break
-            if account.username in tried_accounts:
-                manager.release_account(account)
-                continue
             tried_accounts.add(account.username)
             try:
                 await self._apply_instagram_throttle(account.username)

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -165,7 +165,8 @@ class VideoDownloader:
 
         last_error: Optional[Exception] = None
         tried_accounts: set[str] = set()
-        for attempt in range(2):
+        max_attempts = max(1, len(manager.get_available_accounts()))
+        for attempt in range(max_attempts):
             account = manager.acquire_account()
             if not account:
                 break
@@ -176,12 +177,14 @@ class VideoDownloader:
             try:
                 await self._apply_instagram_throttle(account.username)
                 client = self._build_leased_client(account)
-                return self.instagram_adapter.download_with_instagram_client(
+                result = self.instagram_adapter.download_with_instagram_client(
                     client=client,
                     url=url,
                     output_dir=output_dir,
                     redact_proxy=self._redact_proxy,
                 )
+                manager.record_account_success(account)
+                return result
             except (InstagramAuthError, AuthenticationError) as auth_error:
                 last_error = auth_error
                 logger.warning(
@@ -193,7 +196,7 @@ class VideoDownloader:
                         "error": str(auth_error),
                     },
                 )
-                manager.mark_account_banned(account)
+                manager.record_account_failure(account, "auth_challenge")
             except Exception as error:
                 if isinstance(error, DownloadError):
                     raise

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -167,7 +167,7 @@ class VideoDownloader:
         tried_accounts: set[str] = set()
         max_attempts = max(1, len(manager.get_available_accounts()))
         for attempt in range(max_attempts):
-            account = manager.acquire_account()
+            account = manager.acquire_account(excluded_usernames=tried_accounts)
             if not account:
                 break
             if account.username in tried_accounts:

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -172,7 +172,7 @@ class VideoDownloader:
                 break
             if account.username in tried_accounts:
                 manager.release_account(account)
-                break
+                continue
             tried_accounts.add(account.username)
             try:
                 await self._apply_instagram_throttle(account.username)

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -290,12 +290,13 @@ class AccountManager:
         with self._lock:
             threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
             now = datetime.now()
+            previous_failures = account.consecutive_failures
 
             account.consecutive_failures += 1
             account.last_failure_reason = reason
             account.last_failure_at = now
 
-            threshold_reached = account.consecutive_failures >= threshold
+            threshold_reached = previous_failures < threshold <= account.consecutive_failures
             if threshold_reached:
                 account.is_banned = True
                 account.ban_reason = f"sequential_failures:{reason}"
@@ -442,41 +443,43 @@ class AccountManager:
     
     def reset_banned_accounts(self) -> None:
         """Reset banned status for all accounts."""
-        reset_count = 0
-        for account in self.accounts:
-            if account.is_banned:
-                account.is_banned = False
-                account.ban_reason = None
-                account.banned_at = None
-                account.consecutive_failures = 0
-                account.last_failure_reason = None
-                account.last_failure_at = None
-                reset_count += 1
-        
-        self._save_state()
-        logger.info(f"Reset {reset_count} banned accounts")
+        with self._lock:
+            reset_count = 0
+            for account in self.accounts:
+                if account.is_banned:
+                    account.is_banned = False
+                    account.ban_reason = None
+                    account.banned_at = None
+                    account.consecutive_failures = 0
+                    account.last_failure_reason = None
+                    account.last_failure_at = None
+                    reset_count += 1
+
+            self._save_state()
+            logger.info(f"Reset {reset_count} banned accounts")
     
     def reset_old_banned_accounts(self, hours: int = 24) -> None:
         """Reset accounts that have been banned for more than the specified hours."""
-        reset_count = 0
-        cutoff_time = datetime.now() - timedelta(hours=hours)
-        
-        for account in self.accounts:
-            if account.is_banned and account.banned_at and account.banned_at < cutoff_time:
-                logger.info(f"Resetting account {account.username} (banned {hours}+ hours ago for: {account.ban_reason})")
-                account.is_banned = False
-                account.ban_reason = None
-                account.banned_at = None
-                account.consecutive_failures = 0
-                account.last_failure_reason = None
-                account.last_failure_at = None
-                reset_count += 1
-        
-        if reset_count > 0:
-            self._save_state()
-            logger.info(f"Reset {reset_count} accounts that were banned for more than {hours} hours")
-        else:
-            logger.info(f"No accounts to reset (banned for more than {hours} hours)")
+        with self._lock:
+            reset_count = 0
+            cutoff_time = datetime.now() - timedelta(hours=hours)
+
+            for account in self.accounts:
+                if account.is_banned and account.banned_at and account.banned_at < cutoff_time:
+                    logger.info(f"Resetting account {account.username} (banned {hours}+ hours ago for: {account.ban_reason})")
+                    account.is_banned = False
+                    account.ban_reason = None
+                    account.banned_at = None
+                    account.consecutive_failures = 0
+                    account.last_failure_reason = None
+                    account.last_failure_at = None
+                    reset_count += 1
+
+            if reset_count > 0:
+                self._save_state()
+                logger.info(f"Reset {reset_count} accounts that were banned for more than {hours} hours")
+            else:
+                logger.info(f"No accounts to reset (banned for more than {hours} hours)")
     
     def get_status(self) -> Dict[str, Any]:
         """Get status of all accounts."""

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -4,7 +4,7 @@ import logging
 import random
 import threading
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Set
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
@@ -234,11 +234,13 @@ class AccountManager:
             if not acc.is_banned and acc.password and acc.totp_secret
         ]
     
-    def get_next_account(self) -> Optional[Account]:
+    def get_next_account(self, excluded_usernames: Optional[Set[str]] = None) -> Optional[Account]:
         """Get the next available account for rotation."""
+        excluded_usernames = excluded_usernames or set()
         available = [
             acc for acc in self.get_available_accounts()
             if acc.username not in self._leased_accounts
+            and acc.username not in excluded_usernames
         ]
         
         if not available:
@@ -259,10 +261,10 @@ class AccountManager:
         
         return available[0]
 
-    def acquire_account(self) -> Optional[Account]:
+    def acquire_account(self, excluded_usernames: Optional[Set[str]] = None) -> Optional[Account]:
         """Lease an available account for one concurrent job."""
         with self._lock:
-            account = self.get_next_account()
+            account = self.get_next_account(excluded_usernames=excluded_usernames)
             if not account:
                 return None
             self._leased_accounts.add(account.username)

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -24,6 +24,9 @@ class Account:
     ban_reason: Optional[str] = None  # Reason for being marked unavailable
     banned_at: Optional[datetime] = None  # When the account was banned
     last_used: Optional[datetime] = None
+    consecutive_failures: int = 0
+    last_failure_reason: Optional[str] = None
+    last_failure_at: Optional[datetime] = None
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -37,6 +40,9 @@ class Account:
             'ban_reason': self.ban_reason,
             'banned_at': self.banned_at.isoformat() if self.banned_at else None,
             'last_used': self.last_used.isoformat() if self.last_used else None,
+            'consecutive_failures': self.consecutive_failures,
+            'last_failure_reason': self.last_failure_reason,
+            'last_failure_at': self.last_failure_at.isoformat() if self.last_failure_at else None,
         }
     
     @classmethod
@@ -50,6 +56,8 @@ class Account:
             session_file=Path(data['session_file']) if data.get('session_file') else None,
             is_banned=data.get('is_banned', False),
             ban_reason=data.get('ban_reason'),
+            consecutive_failures=data.get('consecutive_failures', 0),
+            last_failure_reason=data.get('last_failure_reason'),
         )
         
         # Parse datetime fields
@@ -57,8 +65,23 @@ class Account:
             account.banned_at = datetime.fromisoformat(data['banned_at'])
         if data.get('last_used'):
             account.last_used = datetime.fromisoformat(data['last_used'])
+        if data.get('last_failure_at'):
+            account.last_failure_at = datetime.fromisoformat(data['last_failure_at'])
             
         return account
+
+@dataclass
+class AccountHealthEvent:
+    """Structured account health update for alerts and logs."""
+    username: str
+    reason: str
+    consecutive_failures: int
+    threshold: int
+    threshold_reached: bool
+    available_accounts: int
+    total_accounts: int
+    low_watermark: int
+    should_alert_owner: bool
 
 class AccountManager:
     """Manages multiple Instagram accounts with rotation and health tracking."""
@@ -74,6 +97,7 @@ class AccountManager:
         self.sessions_dir.mkdir(exist_ok=True)
         self._leased_accounts: set[str] = set()
         self._lock = threading.Lock()
+        self._last_low_pool_alert_at: Optional[datetime] = None
         
         # Get available proxies
         self.proxies = settings.get_proxy_list()
@@ -170,6 +194,9 @@ class AccountManager:
                         account.is_banned = saved_account.get('is_banned', False)
                         account.ban_reason = saved_account.get('ban_reason')
                         account.banned_at = datetime.fromisoformat(saved_account['banned_at']) if saved_account.get('banned_at') else None
+                        account.consecutive_failures = saved_account.get('consecutive_failures', 0)
+                        account.last_failure_reason = saved_account.get('last_failure_reason')
+                        account.last_failure_at = datetime.fromisoformat(saved_account['last_failure_at']) if saved_account.get('last_failure_at') else None
                         # Update proxy if changed
                         if saved_account.get('proxy'):
                             account.proxy = saved_account['proxy']
@@ -249,6 +276,62 @@ class AccountManager:
             return
         with self._lock:
             self._leased_accounts.discard(account.username)
+
+    def record_account_success(self, account: Account) -> None:
+        """Reset sequential failure tracking after a successful account use."""
+        account.consecutive_failures = 0
+        account.last_failure_reason = None
+        account.last_failure_at = None
+        self._save_state()
+
+    def record_account_failure(self, account: Account, reason: str) -> AccountHealthEvent:
+        """Persist a sequential failure and quarantine accounts at threshold."""
+        threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
+        now = datetime.now()
+
+        account.consecutive_failures += 1
+        account.last_failure_reason = reason
+        account.last_failure_at = now
+
+        threshold_reached = account.consecutive_failures >= threshold
+        if threshold_reached:
+            account.is_banned = True
+            account.ban_reason = f"sequential_failures:{reason}"
+            account.banned_at = now
+            self._leased_accounts.discard(account.username)
+
+        self._save_state()
+
+        return AccountHealthEvent(
+            username=account.username,
+            reason=reason,
+            consecutive_failures=account.consecutive_failures,
+            threshold=threshold,
+            threshold_reached=threshold_reached,
+            available_accounts=len(self.get_available_accounts()),
+            total_accounts=len(self.accounts),
+            low_watermark=settings.ACCOUNT_LOW_WATERMARK,
+            should_alert_owner=self.should_alert_low_pool(),
+        )
+
+    def should_alert_low_pool(self) -> bool:
+        """Return true when the available account pool is below watermark and cooldown elapsed."""
+        low_watermark = settings.ACCOUNT_LOW_WATERMARK
+        if low_watermark <= 0:
+            return False
+        if len(self.get_available_accounts()) >= low_watermark:
+            return False
+
+        now = datetime.now()
+        cooldown = max(0, settings.ACCOUNT_ALERT_COOLDOWN_SECONDS)
+        if (
+            self._last_low_pool_alert_at
+            and (now - self._last_low_pool_alert_at).total_seconds() < cooldown
+        ):
+            return False
+
+        self._last_low_pool_alert_at = now
+        return True
     
     def setup_account(self, account: Account) -> bool:
         """Setup an account for use with instagrapi."""
@@ -362,6 +445,9 @@ class AccountManager:
                 account.is_banned = False
                 account.ban_reason = None
                 account.banned_at = None
+                account.consecutive_failures = 0
+                account.last_failure_reason = None
+                account.last_failure_at = None
                 reset_count += 1
         
         self._save_state()
@@ -378,6 +464,9 @@ class AccountManager:
                 account.is_banned = False
                 account.ban_reason = None
                 account.banned_at = None
+                account.consecutive_failures = 0
+                account.last_failure_reason = None
+                account.last_failure_at = None
                 reset_count += 1
         
         if reset_count > 0:

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -96,7 +96,7 @@ class AccountManager:
         self.sessions_dir = Path('sessions')
         self.sessions_dir.mkdir(exist_ok=True)
         self._leased_accounts: set[str] = set()
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._last_low_pool_alert_at: Optional[datetime] = None
         
         # Get available proxies
@@ -279,59 +279,62 @@ class AccountManager:
 
     def record_account_success(self, account: Account) -> None:
         """Reset sequential failure tracking after a successful account use."""
-        account.consecutive_failures = 0
-        account.last_failure_reason = None
-        account.last_failure_at = None
-        self._save_state()
+        with self._lock:
+            account.consecutive_failures = 0
+            account.last_failure_reason = None
+            account.last_failure_at = None
+            self._save_state()
 
     def record_account_failure(self, account: Account, reason: str) -> AccountHealthEvent:
         """Persist a sequential failure and quarantine accounts at threshold."""
-        threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
-        now = datetime.now()
+        with self._lock:
+            threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
+            now = datetime.now()
 
-        account.consecutive_failures += 1
-        account.last_failure_reason = reason
-        account.last_failure_at = now
+            account.consecutive_failures += 1
+            account.last_failure_reason = reason
+            account.last_failure_at = now
 
-        threshold_reached = account.consecutive_failures >= threshold
-        if threshold_reached:
-            account.is_banned = True
-            account.ban_reason = f"sequential_failures:{reason}"
-            account.banned_at = now
-            self._leased_accounts.discard(account.username)
+            threshold_reached = account.consecutive_failures >= threshold
+            if threshold_reached:
+                account.is_banned = True
+                account.ban_reason = f"sequential_failures:{reason}"
+                account.banned_at = now
+                self._leased_accounts.discard(account.username)
 
-        self._save_state()
+            self._save_state()
 
-        return AccountHealthEvent(
-            username=account.username,
-            reason=reason,
-            consecutive_failures=account.consecutive_failures,
-            threshold=threshold,
-            threshold_reached=threshold_reached,
-            available_accounts=len(self.get_available_accounts()),
-            total_accounts=len(self.accounts),
-            low_watermark=settings.ACCOUNT_LOW_WATERMARK,
-            should_alert_owner=self.should_alert_low_pool(),
-        )
+            return AccountHealthEvent(
+                username=account.username,
+                reason=reason,
+                consecutive_failures=account.consecutive_failures,
+                threshold=threshold,
+                threshold_reached=threshold_reached,
+                available_accounts=len(self.get_available_accounts()),
+                total_accounts=len(self.accounts),
+                low_watermark=settings.ACCOUNT_LOW_WATERMARK,
+                should_alert_owner=threshold_reached and self.should_alert_low_pool(),
+            )
 
     def should_alert_low_pool(self) -> bool:
         """Return true when the available account pool is below watermark and cooldown elapsed."""
-        low_watermark = settings.ACCOUNT_LOW_WATERMARK
-        if low_watermark <= 0:
-            return False
-        if len(self.get_available_accounts()) >= low_watermark:
-            return False
+        with self._lock:
+            low_watermark = settings.ACCOUNT_LOW_WATERMARK
+            if low_watermark <= 0:
+                return False
+            if len(self.get_available_accounts()) >= low_watermark:
+                return False
 
-        now = datetime.now()
-        cooldown = max(0, settings.ACCOUNT_ALERT_COOLDOWN_SECONDS)
-        if (
-            self._last_low_pool_alert_at
-            and (now - self._last_low_pool_alert_at).total_seconds() < cooldown
-        ):
-            return False
+            now = datetime.now()
+            cooldown = max(0, settings.ACCOUNT_ALERT_COOLDOWN_SECONDS)
+            if (
+                self._last_low_pool_alert_at
+                and (now - self._last_low_pool_alert_at).total_seconds() < cooldown
+            ):
+                return False
 
-        self._last_low_pool_alert_at = now
-        return True
+            self._last_low_pool_alert_at = now
+            return True
     
     def setup_account(self, account: Account) -> bool:
         """Setup an account for use with instagrapi."""

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -114,3 +114,24 @@ def test_low_pool_alert_respects_cooldown(monkeypatch, tmp_path: Path):
     manager._last_low_pool_alert_at = manager._last_low_pool_alert_at - timedelta(seconds=3601)
 
     assert manager.should_alert_low_pool() is True
+
+
+def test_repeated_failure_after_quarantine_does_not_alert_again(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 1)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_ALERT_COOLDOWN_SECONDS", 3600)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+
+    first_event = manager.record_account_failure(manager.accounts[0], "challenge_required")
+    manager._last_low_pool_alert_at = manager._last_low_pool_alert_at - timedelta(seconds=3601)
+    repeated_event = manager.record_account_failure(manager.accounts[0], "challenge_required")
+
+    assert first_event.threshold_reached is True
+    assert first_event.should_alert_owner is True
+    assert repeated_event.consecutive_failures == 2
+    assert repeated_event.threshold_reached is False
+    assert repeated_event.should_alert_owner is False

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -77,6 +77,24 @@ def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     assert saved_account["last_failure_at"] is None
 
 
+def test_below_threshold_failure_does_not_alert_when_pool_is_low(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 2)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    manager.accounts[1].is_banned = True
+
+    event = manager.record_account_failure(manager.accounts[0], "timeout")
+
+    assert event.threshold_reached is False
+    assert event.available_accounts == 1
+    assert event.should_alert_owner is False
+    assert manager._last_low_pool_alert_at is None
+
+
 def test_low_pool_alert_respects_cooldown(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 1)

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -1,6 +1,13 @@
+import json
+from datetime import timedelta
 from pathlib import Path
 
 from src.instagram_video_bot.utils import account_manager as account_manager_module
+from src.instagram_video_bot.utils.account_manager import AccountManager
+
+
+def _write_accounts(path, *usernames):
+    path.write_text("\n".join(f"{username}|password|totp" for username in usernames) + "\n")
 
 
 def test_get_account_manager_ignores_directory_placeholder(monkeypatch, tmp_path: Path):
@@ -12,3 +19,80 @@ def test_get_account_manager_ignores_directory_placeholder(monkeypatch, tmp_path
     manager = account_manager_module.get_account_manager()
 
     assert manager is None
+
+
+def test_account_failure_counter_quarantines_after_threshold(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+
+    first_event = manager.record_account_failure(account, "login_failed")
+
+    assert first_event.consecutive_failures == 1
+    assert first_event.threshold_reached is False
+    assert account.is_banned is False
+    assert len(manager.get_available_accounts()) == 2
+
+    second_event = manager.record_account_failure(account, "login_failed")
+
+    assert second_event.consecutive_failures == 2
+    assert second_event.threshold_reached is True
+    assert account.is_banned is True
+    assert account.ban_reason == "sequential_failures:login_failed"
+    assert len(manager.get_available_accounts()) == 1
+
+    state = json.loads(state_file.read_text())
+    saved_account = next(acc for acc in state["accounts"] if acc["username"] == "first")
+    assert saved_account["consecutive_failures"] == 2
+    assert saved_account["last_failure_reason"] == "login_failed"
+    assert saved_account["last_failure_at"]
+
+
+def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+    manager.record_account_failure(account, "timeout")
+
+    manager.record_account_success(account)
+
+    assert account.consecutive_failures == 0
+    assert account.last_failure_reason is None
+    assert account.last_failure_at is None
+    assert account.is_banned is False
+    state = json.loads(state_file.read_text())
+    saved_account = state["accounts"][0]
+    assert saved_account["consecutive_failures"] == 0
+    assert saved_account["last_failure_reason"] is None
+    assert saved_account["last_failure_at"] is None
+
+
+def test_low_pool_alert_respects_cooldown(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 1)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_ALERT_COOLDOWN_SECONDS", 3600)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+
+    first_event = manager.record_account_failure(manager.accounts[0], "challenge_required")
+    second_event = manager.record_account_failure(manager.accounts[1], "challenge_required")
+
+    assert first_event.should_alert_owner is True
+    assert second_event.should_alert_owner is False
+
+    manager._last_low_pool_alert_at = manager._last_low_pool_alert_at - timedelta(seconds=3601)
+
+    assert manager.should_alert_low_pool() is True

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -77,6 +77,20 @@ def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     assert saved_account["last_failure_at"] is None
 
 
+def test_acquire_account_excludes_usernames(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+
+    account = manager.acquire_account(excluded_usernames={"first"})
+
+    assert account is not None
+    assert account.username == "second"
+    assert manager._leased_accounts == {"second"}
+
+
 def test_below_threshold_failure_does_not_alert_when_pool_is_low(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -249,6 +249,79 @@ async def test_duplicate_suppressed_requests_send_media_only_once(monkeypatch, t
 
 
 @pytest.mark.asyncio
+async def test_concurrent_downloads_keep_account_alerts_scoped_to_job(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    alert_update = _FakeUpdate("https://www.instagram.com/reel/alert/", message_id=10)
+    clean_update = _FakeUpdate("https://www.instagram.com/reel/clean/", message_id=11)
+    alert_file = tmp_path / "alert.mp4"
+    clean_file = tmp_path / "clean.mp4"
+    alert_file.write_bytes(b"alert")
+    clean_file.write_bytes(b"clean")
+    downloader_instances = []
+
+    class FakeDownloader:
+        def __init__(self):
+            self.last_account_health_event = None
+            downloader_instances.append(self)
+
+        async def download_video(self, url: str, output_dir: Path):
+            await asyncio.sleep(0)
+            if "alert" in url:
+                self.last_account_health_event = SimpleNamespace(
+                    should_alert_owner=True,
+                    username="acc1",
+                    reason="auth_challenge",
+                    consecutive_failures=2,
+                    threshold=2,
+                    available_accounts=2,
+                    total_accounts=13,
+                    low_watermark=3,
+                )
+                media_file = alert_file
+            else:
+                media_file = clean_file
+            return VideoInfo(
+                file_path=media_file,
+                title="scoped",
+                media_items=[MediaItem(file_path=media_file, media_type="video")],
+                primary_media_type="video",
+            )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.RESULT_CACHE_ENABLED", False)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader)
+
+    await telegram_bot.handle_message(alert_update, context)
+    await telegram_bot.handle_message(clean_update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert len(downloader_instances) == 2
+    assert len({id(instance) for instance in downloader_instances}) == 2
+    assert sum(
+        1 for instance in downloader_instances
+        if getattr(instance.last_account_health_event, "should_alert_owner", False)
+    ) == 1
+    assert len(fake_bot.video_calls) == 2
+    assert [
+        call for call in fake_bot.message_calls
+        if "Instagram account pool warning:" in call["text"]
+    ] == [
+        {
+            "chat_id": 1001,
+            "text": (
+                "Instagram account pool warning:\n"
+                "Usable accounts left: 2 of 13.\n"
+                "Low-watermark threshold: 3.\n"
+                "Last removed account: acc1.\n"
+                "Reason: auth_challenge after 2 sequential failures."
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_chaos_duplicate_request_uses_playful_russian_text(monkeypatch, tmp_path):
     telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
     telegram_bot.state_store.update_group_settings(77, chaos_mode_enabled=True)

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -335,6 +335,42 @@ async def test_download_failure_uses_russian_error_text(monkeypatch, tmp_path):
     assert update.message.status_messages[0].texts[-1] == "Достигнут лимит провайдера. Попробуй позже."
 
 
+@pytest.mark.asyncio
+async def test_download_failure_sends_owner_alert_when_pool_is_low(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    update = _FakeUpdate("https://www.instagram.com/reel/fail/")
+
+    class FakeDownloader:
+        def __init__(self):
+            self.last_account_health_event = SimpleNamespace(
+                should_alert_owner=True,
+                username="acc1",
+                reason="auth_challenge",
+                consecutive_failures=2,
+                threshold=2,
+                available_accounts=2,
+                total_accounts=13,
+                low_watermark=3,
+            )
+
+        async def download_video(self, url: str, output_dir: Path):
+            raise RuntimeError("download failed")
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader)
+
+    await telegram_bot.handle_message(update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert any(
+        call["chat_id"] == 1001
+        and "Instagram account pool warning:" in call["text"]
+        for call in fake_bot.message_calls
+    )
+
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -379,9 +379,12 @@ async def test_download_success_sends_owner_alert_when_retry_quarantines_account
     update = _FakeUpdate("https://www.instagram.com/reel/success/")
     media_file = tmp_path / "success.mp4"
     media_file.write_bytes(b"video")
+    downloader_instances = []
 
     class FakeDownloader:
         def __init__(self):
+            self.attempted_accounts = []
+            self.quarantined_accounts = []
             self.last_account_health_event = SimpleNamespace(
                 should_alert_owner=True,
                 username="acc1",
@@ -392,8 +395,11 @@ async def test_download_success_sends_owner_alert_when_retry_quarantines_account
                 total_accounts=13,
                 low_watermark=3,
             )
+            downloader_instances.append(self)
 
         async def download_video(self, url: str, output_dir: Path):
+            self.attempted_accounts.extend(["acc1", "acc2"])
+            self.quarantined_accounts.append("acc1")
             return VideoInfo(
                 file_path=media_file,
                 title="success",
@@ -409,6 +415,9 @@ async def test_download_success_sends_owner_alert_when_retry_quarantines_account
     await asyncio.gather(*telegram_bot.active_request_tasks.values())
 
     assert len(fake_bot.video_calls) == 1
+    assert len(downloader_instances) == 1
+    assert downloader_instances[0].attempted_accounts == ["acc1", "acc2"]
+    assert downloader_instances[0].quarantined_accounts == ["acc1"]
     assert any(
         call["chat_id"] == 1001
         and "Instagram account pool warning:" in call["text"]

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -371,6 +371,51 @@ async def test_download_failure_sends_owner_alert_when_pool_is_low(monkeypatch, 
     )
 
 
+@pytest.mark.asyncio
+async def test_download_success_sends_owner_alert_when_retry_quarantines_account(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    update = _FakeUpdate("https://www.instagram.com/reel/success/")
+    media_file = tmp_path / "success.mp4"
+    media_file.write_bytes(b"video")
+
+    class FakeDownloader:
+        def __init__(self):
+            self.last_account_health_event = SimpleNamespace(
+                should_alert_owner=True,
+                username="acc1",
+                reason="auth_challenge",
+                consecutive_failures=2,
+                threshold=2,
+                available_accounts=2,
+                total_accounts=13,
+                low_watermark=3,
+            )
+
+        async def download_video(self, url: str, output_dir: Path):
+            return VideoInfo(
+                file_path=media_file,
+                title="success",
+                media_items=[MediaItem(file_path=media_file, media_type="video")],
+                primary_media_type="video",
+            )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.RESULT_CACHE_ENABLED", False)
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader)
+
+    await telegram_bot.handle_message(update, context)
+    await asyncio.gather(*telegram_bot.active_request_tasks.values())
+
+    assert len(fake_bot.video_calls) == 1
+    assert any(
+        call["chat_id"] == 1001
+        and "Instagram account pool warning:" in call["text"]
+        for call in fake_bot.message_calls
+    )
+
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -8,6 +8,7 @@ from src.instagram_video_bot.services.state_store import StateStore
 from src.instagram_video_bot.services.job_manager import SharedJob, RequestRecord
 from src.instagram_video_bot.services.telegram_bot import RequestContext, TelegramBot
 from src.instagram_video_bot.services.video_downloader import MediaItem, VideoInfo
+from src.instagram_video_bot.utils.account_manager import AccountHealthEvent
 
 
 class _FakeBot:
@@ -15,7 +16,11 @@ class _FakeBot:
         self.video_calls = []
         self.photo_calls = []
         self.group_calls = []
+        self.message_calls = []
         self.member_status = member_status
+
+    async def send_message(self, **kwargs):
+        self.message_calls.append(kwargs)
 
     async def send_video(self, **kwargs):
         self.video_calls.append(kwargs)
@@ -358,6 +363,65 @@ def test_build_caption_text_truncates_long_titles():
 
     assert len(caption) == TelegramBot.MAX_MEDIA_CAPTION_LENGTH
     assert caption.endswith("...")
+
+
+@pytest.mark.asyncio
+async def test_owner_low_account_pool_alert_is_english(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    event = AccountHealthEvent(
+        username="acc1",
+        reason="auth_challenge",
+        consecutive_failures=2,
+        threshold=2,
+        threshold_reached=True,
+        available_accounts=2,
+        total_accounts=13,
+        low_watermark=3,
+        should_alert_owner=True,
+    )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+
+    await telegram_bot._notify_owner_about_low_account_pool(context, event)
+
+    assert fake_bot.message_calls == [
+        {
+            "chat_id": 1001,
+            "text": (
+                "Instagram account pool warning:\n"
+                "Usable accounts left: 2 of 13.\n"
+                "Low-watermark threshold: 3.\n"
+                "Last removed account: acc1.\n"
+                "Reason: auth_challenge after 2 sequential failures."
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_owner_low_account_pool_alert_skips_without_owner(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    event = AccountHealthEvent(
+        username="acc1",
+        reason="auth_challenge",
+        consecutive_failures=2,
+        threshold=2,
+        threshold_reached=True,
+        available_accounts=2,
+        total_accounts=13,
+        low_watermark=3,
+        should_alert_owner=True,
+    )
+
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", None)
+
+    await telegram_bot._notify_owner_about_low_account_pool(context, event)
+
+    assert fake_bot.message_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -116,6 +117,16 @@ class _DuplicateLeaseManager(_LeaseManager):
             if account.username not in excluded_usernames:
                 return self.lease_sequence.pop(index)
         return None
+
+
+class _HealthEventLeaseManager(_LeaseManager):
+    def __init__(self, accounts, events):
+        super().__init__(accounts)
+        self.events = list(events)
+
+    def record_account_failure(self, account, reason):
+        super().record_account_failure(account, reason)
+        return self.events.pop(0)
 
 
 class _Account:
@@ -371,6 +382,36 @@ async def test_download_fails_after_retry_on_auth_failure(monkeypatch, tmp_path)
 
     with pytest.raises(DownloadError, match="Authentication failed"):
         await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_download_preserves_first_alert_worthy_account_health_event(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    first_alert_event = SimpleNamespace(should_alert_owner=True, username="acc_fail_1")
+    later_non_alert_event = SimpleNamespace(should_alert_owner=False, username="acc_fail_2")
+    manager = _HealthEventLeaseManager(
+        [_Account("acc_fail_1"), _Account("acc_fail_2")],
+        [first_alert_event, later_non_alert_event],
+    )
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    def _client_factory(**kwargs):
+        return _AuthFailClient()
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.InstagramClient", _client_factory)
+
+    with pytest.raises(DownloadError, match="Authentication failed"):
+        await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert manager.failures == [
+        ("acc_fail_1", "auth_challenge"),
+        ("acc_fail_2", "auth_challenge"),
+    ]
+    assert downloader.last_account_health_event is first_alert_event
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -83,10 +83,12 @@ class _LeaseManager:
     def get_available_accounts(self):
         return list(self.accounts)
 
-    def acquire_account(self):
-        if not self.accounts:
-            return None
-        return self.accounts.pop(0)
+    def acquire_account(self, excluded_usernames=None):
+        excluded_usernames = excluded_usernames or set()
+        for index, account in enumerate(self.accounts):
+            if account.username not in excluded_usernames:
+                return self.accounts.pop(index)
+        return None
 
     def release_account(self, account):
         if account:
@@ -101,6 +103,19 @@ class _LeaseManager:
 
     def record_account_success(self, account):
         self.successes.append(account.username)
+
+
+class _DuplicateLeaseManager(_LeaseManager):
+    def __init__(self, accounts, lease_sequence):
+        super().__init__(accounts)
+        self.lease_sequence = list(lease_sequence)
+
+    def acquire_account(self, excluded_usernames=None):
+        excluded_usernames = excluded_usernames or set()
+        for index, account in enumerate(self.lease_sequence):
+            if account.username not in excluded_usernames:
+                return self.lease_sequence.pop(index)
+        return None
 
 
 class _Account:
@@ -283,6 +298,42 @@ async def test_download_skips_duplicate_leased_accounts(monkeypatch, tmp_path):
 
     acc_fail = _Account("acc_fail")
     manager = _LeaseManager([acc_fail, acc_fail, _Account("acc_ok")])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_fail": _AuthFailClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+
+    def _client_factory(**kwargs):
+        return clients[kwargs["username"]]
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.InstagramClient", _client_factory)
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert info.title == "ok"
+    assert manager.failures == [("acc_fail", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
+
+
+@pytest.mark.asyncio
+async def test_download_retry_budget_counts_unique_account_leases(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "video_retry_unique_budget.mp4"
+    expected_path.write_bytes(b"video")
+
+    acc_fail = _Account("acc_fail")
+    acc_ok = _Account("acc_ok")
+    manager = _DuplicateLeaseManager(
+        accounts=[acc_fail, acc_ok],
+        lease_sequence=[acc_fail, acc_fail, acc_fail, acc_ok],
+    )
     monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
 
     clients = {

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -254,6 +254,37 @@ async def test_download_with_account_lease_retries_after_auth_failure(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_success_preserves_pending_account_pool_alert(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "video_retry_alert.mp4"
+    expected_path.write_bytes(b"video")
+    alert_event = SimpleNamespace(should_alert_owner=True, username="acc_fail")
+    manager = _HealthEventLeaseManager([_Account("acc_fail"), _Account("acc_ok")], [alert_event])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_fail": _AuthFailClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+
+    def _client_factory(**kwargs):
+        return clients[kwargs["username"]]
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.InstagramClient", _client_factory)
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert downloader.last_account_health_event is alert_event
+    assert manager.failures == [("acc_fail", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
+
+
+@pytest.mark.asyncio
 async def test_download_retries_across_all_available_accounts(monkeypatch, tmp_path):
     downloader = VideoDownloader()
     downloader.min_delay_between_downloads = 0

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -272,6 +272,38 @@ async def test_download_retries_across_all_available_accounts(monkeypatch, tmp_p
 
 
 @pytest.mark.asyncio
+async def test_download_skips_duplicate_leased_accounts(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "video_retry_duplicate.mp4"
+    expected_path.write_bytes(b"video")
+
+    acc_fail = _Account("acc_fail")
+    manager = _LeaseManager([acc_fail, acc_fail, _Account("acc_ok")])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_fail": _AuthFailClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+
+    def _client_factory(**kwargs):
+        return clients[kwargs["username"]]
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.InstagramClient", _client_factory)
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert info.title == "ok"
+    assert manager.failures == [("acc_fail", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
+
+
+@pytest.mark.asyncio
 async def test_download_fails_after_retry_on_auth_failure(monkeypatch, tmp_path):
     downloader = VideoDownloader()
     downloader.min_delay_between_downloads = 0

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -77,6 +77,11 @@ class _LeaseManager:
         self.accounts = list(accounts)
         self.released = []
         self.banned = []
+        self.failures = []
+        self.successes = []
+
+    def get_available_accounts(self):
+        return list(self.accounts)
 
     def acquire_account(self):
         if not self.accounts:
@@ -89,6 +94,13 @@ class _LeaseManager:
 
     def mark_account_banned(self, account):
         self.banned.append(account.username)
+
+    def record_account_failure(self, account, reason):
+        self.failures.append((account.username, reason))
+        self.banned.append(account.username)
+
+    def record_account_success(self, account):
+        self.successes.append(account.username)
 
 
 class _Account:
@@ -211,7 +223,52 @@ async def test_download_with_account_lease_retries_after_auth_failure(monkeypatc
 
     assert info.file_path == expected_path
     assert info.title == "ok"
-    assert manager.banned == ["acc_fail"]
+    assert manager.failures == [("acc_fail", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
+
+
+@pytest.mark.asyncio
+async def test_download_retries_across_all_available_accounts(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "video_retry_all.mp4"
+    expected_path.write_bytes(b"video")
+
+    manager = _LeaseManager(
+        [
+            _Account("acc_fail_1"),
+            _Account("acc_fail_2"),
+            _Account("acc_fail_3"),
+            _Account("acc_ok"),
+        ]
+    )
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_fail_1": _AuthFailClient(),
+        "acc_fail_2": _AuthFailClient(),
+        "acc_fail_3": _AuthFailClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+
+    def _client_factory(**kwargs):
+        return clients[kwargs["username"]]
+
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.InstagramClient", _client_factory)
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert info.title == "ok"
+    assert manager.failures == [
+        ("acc_fail_1", "auth_challenge"),
+        ("acc_fail_2", "auth_challenge"),
+        ("acc_fail_3", "auth_challenge"),
+    ]
+    assert manager.successes == ["acc_ok"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Track sequential Instagram account failures and auto-quarantine accounts via state after the configured threshold.
- Retry downloads across all available accounts while excluding already-tried accounts.
- Send an English owner DM when the usable account pool drops below the configured watermark.

## Test Plan
- uv run pytest -q
- git diff --check
- uv run python manage_accounts.py status