### PR TITLE
[codex] Fix Telegram video aspect metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PYTHONUNBUFFERED=1 \
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
+    ffmpeg \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/instagram_video_bot/services/download_models.py
+++ b/src/instagram_video_bot/services/download_models.py
@@ -15,6 +15,8 @@ class MediaItem:
     media_type: Literal["video", "photo"]
     caption: Optional[str] = None
     duration: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
 
 
 @dataclass

--- a/src/instagram_video_bot/services/instagram_fast_extractor.py
+++ b/src/instagram_video_bot/services/instagram_fast_extractor.py
@@ -32,6 +32,8 @@ class ExtractedMedia:
     url: str
     media_type: _MEDIA_TYPE
     duration: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
 
 
 @dataclass
@@ -41,6 +43,8 @@ class DownloadedMedia:
     file_path: Path
     media_type: _MEDIA_TYPE
     duration: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
 
 
 @dataclass
@@ -328,9 +332,11 @@ class InstagramFastExtractor:
             best = self._pick_highest_resolution_video(video_versions)
             if best:
                 return ExtractedMedia(
-                    url=best,
+                    url=str(best["url"]),
                     media_type="video",
                     duration=self._safe_float(node.get("video_duration")),
+                    width=self._safe_int(best.get("width")),
+                    height=self._safe_int(best.get("height")),
                 )
 
         image_versions = node.get("image_versions2")
@@ -385,11 +391,14 @@ class InstagramFastExtractor:
                     if not isinstance(media_node, dict):
                         continue
                     if media_node.get("is_video") and media_node.get("video_url"):
+                        width, height = self._parse_graphql_dimensions(media_node)
                         out.append(
                             ExtractedMedia(
                                 url=str(media_node["video_url"]),
                                 media_type="video",
                                 duration=self._safe_float(media_node.get("video_duration")),
+                                width=width,
+                                height=height,
                             )
                         )
                     elif media_node.get("display_url"):
@@ -404,6 +413,7 @@ class InstagramFastExtractor:
                     return caption_text, out
 
         if node.get("video_url"):
+            width, height = self._parse_graphql_dimensions(node)
             return (
                 caption_text,
                 [
@@ -411,6 +421,8 @@ class InstagramFastExtractor:
                         url=str(node["video_url"]),
                         media_type="video",
                         duration=self._safe_float(node.get("video_duration")),
+                        width=width,
+                        height=height,
                     )
                 ],
             )
@@ -474,6 +486,8 @@ class InstagramFastExtractor:
                     file_path=out_path,
                     media_type=item.media_type,
                     duration=item.duration,
+                    width=item.width,
+                    height=item.height,
                 )
             )
 
@@ -540,9 +554,9 @@ class InstagramFastExtractor:
         return None
 
     @staticmethod
-    def _pick_highest_resolution_video(video_versions: List[Dict[str, Any]]) -> Optional[str]:
+    def _pick_highest_resolution_video(video_versions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Pick best video candidate by pixel area."""
-        best_url: Optional[str] = None
+        best_item: Optional[Dict[str, Any]] = None
         best_area = -1
         for item in video_versions:
             if not isinstance(item, dict) or not item.get("url"):
@@ -552,8 +566,15 @@ class InstagramFastExtractor:
             area = width * height
             if area > best_area:
                 best_area = area
-                best_url = str(item["url"])
-        return best_url
+                best_item = item
+        return best_item
+
+    @classmethod
+    def _parse_graphql_dimensions(cls, node: Dict[str, Any]) -> tuple[Optional[int], Optional[int]]:
+        dimensions = node.get("dimensions")
+        if not isinstance(dimensions, dict):
+            return None, None
+        return cls._safe_int(dimensions.get("width")), cls._safe_int(dimensions.get("height"))
 
     @staticmethod
     def _safe_float(value: Any) -> Optional[float]:
@@ -562,6 +583,16 @@ class InstagramFastExtractor:
             if value is None:
                 return None
             return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_int(value: Any) -> Optional[int]:
+        """Convert value to int if possible."""
+        try:
+            if value is None:
+                return None
+            return int(value)
         except (TypeError, ValueError):
             return None
 

--- a/src/instagram_video_bot/services/media_metadata.py
+++ b/src/instagram_video_bot/services/media_metadata.py
@@ -1,0 +1,139 @@
+"""Local media metadata probing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import logging
+from pathlib import Path
+import subprocess
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MediaMetadata:
+    """Video metadata relevant for Telegram delivery."""
+
+    duration: Optional[float] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+
+def probe_video_metadata(file_path: Path) -> MediaMetadata:
+    """Probe video metadata with ffprobe, returning empty metadata on failure."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=width,height,duration,sample_aspect_ratio:stream_side_data=rotation",
+                "-of",
+                "json",
+                str(file_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.warning("ffprobe is not installed; video metadata will be inferred by Telegram")
+        return MediaMetadata()
+    except Exception as error:
+        logger.warning("Failed to probe video metadata for %s: %s", file_path, error)
+        return MediaMetadata()
+
+    if result.returncode != 0:
+        logger.warning(
+            "ffprobe failed for %s",
+            file_path,
+            extra={"stderr": result.stderr.strip()},
+        )
+        return MediaMetadata()
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        logger.warning("ffprobe returned invalid JSON for %s", file_path)
+        return MediaMetadata()
+
+    streams = payload.get("streams") if isinstance(payload, dict) else None
+    if not streams:
+        return MediaMetadata()
+
+    stream = streams[0]
+    if not isinstance(stream, dict):
+        return MediaMetadata()
+
+    width = _safe_int(stream.get("width"))
+    height = _safe_int(stream.get("height"))
+    duration = _safe_float(stream.get("duration"))
+
+    if _has_right_angle_rotation(stream) and width and height:
+        width, height = height, width
+
+    width, height = _apply_sample_aspect_ratio(
+        width,
+        height,
+        str(stream.get("sample_aspect_ratio") or ""),
+    )
+    return MediaMetadata(duration=duration, width=width, height=height)
+
+
+def _has_right_angle_rotation(stream: dict[str, Any]) -> bool:
+    side_data = stream.get("side_data_list")
+    if not isinstance(side_data, list):
+        return False
+    for item in side_data:
+        if not isinstance(item, dict):
+            continue
+        rotation = _safe_int(item.get("rotation"))
+        if rotation is not None and abs(rotation) % 180 == 90:
+            return True
+    return False
+
+
+def _apply_sample_aspect_ratio(
+    width: Optional[int],
+    height: Optional[int],
+    sample_aspect_ratio: str,
+) -> tuple[Optional[int], Optional[int]]:
+    if not width or not height or not sample_aspect_ratio or sample_aspect_ratio in {"1:1", "0:1"}:
+        return width, height
+
+    try:
+        numerator_raw, denominator_raw = sample_aspect_ratio.split(":", 1)
+        numerator = int(numerator_raw)
+        denominator = int(denominator_raw)
+    except (TypeError, ValueError):
+        return width, height
+
+    if numerator <= 0 or denominator <= 0:
+        return width, height
+
+    display_width = round(width * numerator / denominator)
+    return max(1, display_width), height
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value in (None, "N/A"):
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        if value in (None, "N/A"):
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/src/instagram_video_bot/services/media_metadata.py
+++ b/src/instagram_video_bot/services/media_metadata.py
@@ -75,14 +75,15 @@ def probe_video_metadata(file_path: Path) -> MediaMetadata:
     height = _safe_int(stream.get("height"))
     duration = _safe_float(stream.get("duration"))
 
-    if _has_right_angle_rotation(stream) and width and height:
-        width, height = height, width
-
     width, height = _apply_sample_aspect_ratio(
         width,
         height,
         str(stream.get("sample_aspect_ratio") or ""),
     )
+
+    if _has_right_angle_rotation(stream) and width and height:
+        width, height = height, width
+
     return MediaMetadata(duration=duration, width=width, height=height)
 
 

--- a/src/instagram_video_bot/services/provider_adapters.py
+++ b/src/instagram_video_bot/services/provider_adapters.py
@@ -144,7 +144,7 @@ class InstagramProviderAdapter:
         return VideoInfo(
             file_path=file_path,
             title=media_info.get("title", ""),
-            duration=media_info.get("duration"),
+            duration=media_item.duration,
             description=media_info.get("title", ""),
             media_items=[media_item],
             primary_media_type=media_type,
@@ -181,9 +181,10 @@ class InstagramProviderAdapter:
         height: int | None = None,
     ) -> MediaItem:
         """Build a media item and fill missing video metadata from the local file."""
-        if media_type == "video" and (duration is None or not width or not height):
+        duration_is_missing = InstagramProviderAdapter._is_missing_video_duration(duration)
+        if media_type == "video" and (duration_is_missing or not width or not height):
             metadata = probe_video_metadata(file_path)
-            duration = duration if duration is not None else metadata.duration
+            duration = metadata.duration if duration_is_missing else duration
             width = width or metadata.width
             height = height or metadata.height
 
@@ -195,6 +196,15 @@ class InstagramProviderAdapter:
             width=width,
             height=height,
         )
+
+    @staticmethod
+    def _is_missing_video_duration(duration: float | int | None) -> bool:
+        if duration is None:
+            return True
+        try:
+            return float(duration) <= 0
+        except (TypeError, ValueError):
+            return True
 
 
 class TwitterProviderAdapter:

--- a/src/instagram_video_bot/services/provider_adapters.py
+++ b/src/instagram_video_bot/services/provider_adapters.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional, cast
 
 from .download_models import AuthenticationError, DownloadError, MediaItem, VideoInfo
 from .instagram_client import InstagramAuthError, InstagramClient
 from .instagram_fast_extractor import InstagramFastExtractor, InstagramFastExtractorError
+from .media_metadata import probe_video_metadata
 from .twitter_downloader import TwitterDownloadError, TwitterDownloader
 from .youtube_downloader import YouTubeDownloadError, YouTubeShortsDownloader
 from ..config.settings import settings
@@ -65,11 +66,13 @@ class InstagramProviderAdapter:
             raise InstagramFastExtractorError("Fast extractor returned no media")
 
         media_items = [
-            MediaItem(
+            self._build_media_item(
                 file_path=item.file_path,
                 media_type=item.media_type,
                 caption=result.caption or None,
                 duration=item.duration,
+                width=item.width,
+                height=item.height,
             )
             for item in result.media_items
         ]
@@ -132,7 +135,7 @@ class InstagramProviderAdapter:
             )
 
         media_type = self._infer_media_type(file_path)
-        media_item = MediaItem(
+        media_item = self._build_media_item(
             file_path=file_path,
             media_type=media_type,
             caption=media_info.get("title") or None,
@@ -167,6 +170,32 @@ class InstagramProviderAdapter:
             return "video"
         return "photo"
 
+    @staticmethod
+    def _build_media_item(
+        *,
+        file_path: Path,
+        media_type: str,
+        caption: str | None = None,
+        duration: float | int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+    ) -> MediaItem:
+        """Build a media item and fill missing video metadata from the local file."""
+        if media_type == "video" and (duration is None or not width or not height):
+            metadata = probe_video_metadata(file_path)
+            duration = duration if duration is not None else metadata.duration
+            width = width or metadata.width
+            height = height or metadata.height
+
+        return MediaItem(
+            file_path=file_path,
+            media_type=cast(Literal["video", "photo"], media_type),
+            caption=caption,
+            duration=duration,
+            width=width,
+            height=height,
+        )
+
 
 class TwitterProviderAdapter:
     """Twitter/X adapter around yt-dlp downloader."""
@@ -184,7 +213,7 @@ class TwitterProviderAdapter:
             raise DownloadError("Twitter/X download returned no media items")
 
         media_items = [
-            MediaItem(
+            InstagramProviderAdapter._build_media_item(
                 file_path=item.file_path,
                 media_type=item.media_type,
                 caption=result.title or None,
@@ -217,7 +246,7 @@ class YouTubeShortsProviderAdapter:
             raise DownloadError("YouTube Shorts download returned no media items")
 
         media_items = [
-            MediaItem(
+            InstagramProviderAdapter._build_media_item(
                 file_path=item.file_path,
                 media_type=item.media_type,
                 caption=result.title or None,

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -421,6 +421,8 @@ class TelegramBot:
                             "media_type": item.media_type,
                             "caption": item.caption,
                             "duration": item.duration,
+                            "width": item.width,
+                            "height": item.height,
                         }
                         for item in video_info.media_items
                     ],
@@ -502,11 +504,13 @@ class TelegramBot:
             media_item = media_items[0]
             with open(media_item.file_path, "rb") as media_file:
                 if media_item.media_type == "video":
+                    video_kwargs = self._telegram_video_kwargs(media_item)
                     await context.bot.send_video(
                         chat_id=request_context.chat_id,
                         video=media_file,
                         caption=caption_text,
                         reply_to_message_id=request_context.original_message_id,
+                        **video_kwargs,
                     )
                 else:
                     await context.bot.send_photo(
@@ -523,7 +527,13 @@ class TelegramBot:
                 media_file = stack.enter_context(open(media_item.file_path, "rb"))
                 item_caption = caption_text if index == 0 else None
                 if media_item.media_type == "video":
-                    media_group.append(InputMediaVideo(media=media_file, caption=item_caption))
+                    media_group.append(
+                        InputMediaVideo(
+                            media=media_file,
+                            caption=item_caption,
+                            **self._telegram_video_kwargs(media_item),
+                        )
+                    )
                 else:
                     media_group.append(InputMediaPhoto(media=media_file, caption=item_caption))
 
@@ -560,6 +570,8 @@ class TelegramBot:
                 media_type=item["media_type"],
                 caption=item.get("caption"),
                 duration=item.get("duration"),
+                width=item.get("width"),
+                height=item.get("height"),
             )
             for item in cached.media_items
         ]
@@ -597,6 +609,20 @@ class TelegramBot:
         if len(full_caption) <= cls.MAX_MEDIA_CAPTION_LENGTH:
             return full_caption
         return full_caption[: cls.MAX_MEDIA_CAPTION_LENGTH - 3].rstrip() + "..."
+
+    @staticmethod
+    def _telegram_video_kwargs(media_item: MediaItem) -> dict[str, object]:
+        """Build optional Telegram video metadata from a media item."""
+        kwargs: dict[str, object] = {}
+        if media_item.width:
+            kwargs["width"] = int(media_item.width)
+        if media_item.height:
+            kwargs["height"] = int(media_item.height)
+        if media_item.duration is not None:
+            kwargs["duration"] = max(0, round(float(media_item.duration)))
+        if media_item.file_path.suffix.lower() in {".mp4", ".mov"}:
+            kwargs["supports_streaming"] = True
+        return kwargs
 
     @staticmethod
     def _build_error_message(error: Exception, *, chaos_enabled: bool = False) -> str:

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import ExitStack
 from dataclasses import dataclass
+import datetime as dtm
 import logging
 from pathlib import Path
 import time
@@ -619,7 +620,7 @@ class TelegramBot:
         if media_item.height:
             kwargs["height"] = int(media_item.height)
         if media_item.duration is not None:
-            kwargs["duration"] = max(0, round(float(media_item.duration)))
+            kwargs["duration"] = dtm.timedelta(seconds=max(0, round(float(media_item.duration))))
         if media_item.file_path.suffix.lower() in {".mp4", ".mov"}:
             kwargs["supports_streaming"] = True
         return kwargs

--- a/tests/test_media_metadata.py
+++ b/tests/test_media_metadata.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from src.instagram_video_bot.services.media_metadata import probe_video_metadata
+
+
+def test_probe_video_metadata_applies_sample_aspect_ratio_before_rotation(monkeypatch, tmp_path):
+    video_file = tmp_path / "rotated.mp4"
+    video_file.write_bytes(b"video")
+
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=0,
+            stdout=(
+                "{"
+                '"streams": ['
+                "{"
+                '"width": 480,'
+                '"height": 640,'
+                '"duration": "3.5",'
+                '"sample_aspect_ratio": "2:1",'
+                '"side_data_list": [{"rotation": 90}]'
+                "}"
+                "]"
+                "}"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.media_metadata.subprocess.run",
+        fake_run,
+    )
+
+    metadata = probe_video_metadata(video_file)
+
+    assert metadata.duration == 3.5
+    assert metadata.width == 640
+    assert metadata.height == 960

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -129,6 +129,39 @@ async def test_send_single_video_uses_send_video(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_send_single_video_passes_probe_metadata_to_telegram(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    video_file = tmp_path / "portrait.mp4"
+    video_file.write_bytes(b"video")
+
+    info = VideoInfo(
+        file_path=video_file,
+        title="Portrait reel",
+        media_items=[
+            MediaItem(
+                file_path=video_file,
+                media_type="video",
+                duration=11.6,
+                width=720,
+                height=1280,
+            )
+        ],
+        primary_media_type="video",
+    )
+
+    await telegram_bot._send_media(context, request_context, info)
+
+    assert fake_bot.video_calls[0]["width"] == 720
+    assert fake_bot.video_calls[0]["height"] == 1280
+    assert fake_bot.video_calls[0]["duration"] == 12
+    assert fake_bot.video_calls[0]["supports_streaming"] is True
+
+
+@pytest.mark.asyncio
 async def test_send_single_photo_uses_send_photo(tmp_path):
     telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
     fake_bot = _FakeBot()
@@ -180,6 +213,43 @@ async def test_send_carousel_uses_media_group(tmp_path):
     assert len(fake_bot.photo_calls) == 0
     assert len(fake_bot.group_calls) == 1
     assert len(fake_bot.group_calls[0]["media"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_send_media_group_video_includes_probe_metadata(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    first = tmp_path / "1.jpg"
+    second = tmp_path / "2.mp4"
+    first.write_bytes(b"photo")
+    second.write_bytes(b"video")
+
+    info = VideoInfo(
+        file_path=first,
+        title="Album title",
+        media_items=[
+            MediaItem(file_path=first, media_type="photo"),
+            MediaItem(
+                file_path=second,
+                media_type="video",
+                duration=4.2,
+                width=1080,
+                height=1920,
+            ),
+        ],
+        primary_media_type="photo",
+    )
+
+    await telegram_bot._send_media(context, request_context, info)
+
+    video_media = fake_bot.group_calls[0]["media"][1]
+    assert video_media.width == 1080
+    assert video_media.height == 1920
+    assert video_media.duration == 4
+    assert video_media.supports_streaming is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime as dtm
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -157,7 +158,7 @@ async def test_send_single_video_passes_probe_metadata_to_telegram(tmp_path):
 
     assert fake_bot.video_calls[0]["width"] == 720
     assert fake_bot.video_calls[0]["height"] == 1280
-    assert fake_bot.video_calls[0]["duration"] == 12
+    assert fake_bot.video_calls[0]["duration"] == dtm.timedelta(seconds=12)
     assert fake_bot.video_calls[0]["supports_streaming"] is True
 
 
@@ -248,7 +249,7 @@ async def test_send_media_group_video_includes_probe_metadata(tmp_path):
     video_media = fake_bot.group_calls[0]["media"][1]
     assert video_media.width == 1080
     assert video_media.height == 1920
-    assert video_media.duration == 4
+    assert video_media._duration == dtm.timedelta(seconds=4)
     assert video_media.supports_streaming is True
 
 

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -9,6 +9,8 @@ from src.instagram_video_bot.services.instagram_fast_extractor import (
     FastExtractorDownloadResult,
     InstagramFastExtractorError,
 )
+from src.instagram_video_bot.services.media_metadata import MediaMetadata
+from src.instagram_video_bot.services.provider_adapters import InstagramProviderAdapter
 from src.instagram_video_bot.services.video_downloader import (
     DownloadError,
     MediaItem,
@@ -136,6 +138,26 @@ class _Account:
         self.proxy = None
         self.totp_secret = "totp"
         self.session_file = None
+
+
+def test_build_media_item_treats_zero_duration_as_missing(monkeypatch, tmp_path):
+    video_file = tmp_path / "legacy.mp4"
+    video_file.write_bytes(b"video")
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.provider_adapters.probe_video_metadata",
+        lambda _path: MediaMetadata(duration=12.4, width=720, height=1280),
+    )
+
+    media_item = InstagramProviderAdapter._build_media_item(
+        file_path=video_file,
+        media_type="video",
+        duration=0,
+    )
+
+    assert media_item.duration == 12.4
+    assert media_item.width == 720
+    assert media_item.height == 1280
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes large Instagram reels rendering with an incorrect aspect ratio after the bot sends them to Telegram.

The root cause is that the bot previously uploaded videos without explicit Telegram video metadata. For some larger Instagram CDN MP4 variants, Telegram clients can infer the wrong display geometry from the container. The fix preserves dimensions from the Instagram fast extractor when available, probes downloaded video files with `ffprobe` as a fallback, and passes width, height, duration, and streaming metadata to Telegram for both single videos and media groups.

Closes #14.

## Changes

- Add width and height fields to `MediaItem`.
- Add `ffprobe`-based video metadata probing.
- Preserve source video dimensions from Instagram fast extraction.
- Pass video metadata to `send_video()` and `InputMediaVideo`.
- Install `ffmpeg` in the Docker image so `ffprobe` is available at runtime.
- Add regression tests for Telegram video metadata delivery.

## Validation

- `.venv/bin/python -m pytest -q tests` -> 104 passed, 1 PTB deprecation warning.
- `git diff --check` -> clean.
- `docker build -t inst-video-bot:aspect-metadata .` -> succeeded.
- `docker run --rm --entrypoint ffprobe inst-video-bot:aspect-metadata -version` -> confirmed ffprobe 7.1.3 in the image.

## Docker Cleanup

Removed the local verification images and pruned Docker builder cache after validation:

- Removed `inst-video-bot:aspect-metadata`.
- Removed older local `inst-video-bot:instagrapi-2-5-15`.
- Pruned 2.921 GB of Docker builder cache.

Unrelated local `pgvector/pgvector:pg16`, `qubera-postgres`, and `issue-*_pgdata` artifacts were left untouched.
