### PR TITLE
[codex] add global admin status

### DIFF
--- a/src/instagram_video_bot/services/chaos_text.py
+++ b/src/instagram_video_bot/services/chaos_text.py
@@ -30,7 +30,7 @@ class ChaosText:
             "Поддерживаю: Instagram, Twitter/X и YouTube Shorts.\n"
             "Команды: /help, /status, /formats, /cancel, /stats, /chaos status\n"
             "Настройки владельца: /quiet on|off, /dupes on|off, /statsmode on|off, "
-            "/chatlimit <n>, /userlimit <n>, /admin_status\n"
+            "/chatlimit <n>, /userlimit <n>, /admin_status, /admin_global_status\n"
             f"{chaos_line}"
         )
 

--- a/src/instagram_video_bot/services/job_manager.py
+++ b/src/instagram_video_bot/services/job_manager.py
@@ -292,6 +292,24 @@ class JobManager:
             "user_limit": limits["user_max_active_jobs"],
         }
 
+    def get_global_snapshot(self) -> dict[str, int]:
+        active = 0
+        queued = 0
+        watchers = 0
+        for job in self._jobs.values():
+            if job.state == "running":
+                active += 1
+            elif job.state == "queued":
+                queued += 1
+            if job.state not in {"completed", "failed", "cancelled"}:
+                watchers += sum(1 for request in job.requesters.values() if request.active)
+        return {
+            "active_jobs": active,
+            "queued_jobs": queued,
+            "active_requests": watchers,
+            "global_limit": settings.GLOBAL_MAX_CONCURRENT_JOBS,
+        }
+
     def update_chat_limits(self, chat_id: int, *, chat_limit: int | None = None, user_limit: int | None = None) -> None:
         """Refresh in-memory semaphores for updated owner-defined limits."""
         if chat_limit is not None:

--- a/src/instagram_video_bot/services/state_store.py
+++ b/src/instagram_video_bot/services/state_store.py
@@ -424,18 +424,29 @@ class StateStore:
             (status, now, job_id),
         )
 
-    def get_performance_summary(self, chat_id: int, limit: int = 50) -> dict[str, Any]:
+    def get_performance_summary(self, chat_id: int | None, limit: int = 50) -> dict[str, Any]:
         with self._lock:
-            rows = self._conn.execute(
-                """
-                SELECT *
-                FROM performance_metrics
-                WHERE chat_id = ?
-                ORDER BY finished_at DESC, created_at DESC
-                LIMIT ?
-                """,
-                (chat_id, limit),
-            ).fetchall()
+            if chat_id is None:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM performance_metrics
+                    ORDER BY finished_at DESC, created_at DESC
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """
+                    SELECT *
+                    FROM performance_metrics
+                    WHERE chat_id = ?
+                    ORDER BY finished_at DESC, created_at DESC
+                    LIMIT ?
+                    """,
+                    (chat_id, limit),
+                ).fetchall()
 
         total_jobs = len(rows)
         cache_hits = sum(1 for row in rows if row["cache_hit"])
@@ -706,6 +717,69 @@ class StateStore:
             "queued_jobs": int(queued),
             "running_jobs": int(running),
             "failed_jobs": int(failed_jobs),
+            "provider_job_counts": [
+                (row["provider"], row["status"], int(row["count"])) for row in provider_job_counts
+            ],
+            "recent_failures": [
+                (
+                    row["provider"],
+                    row["normalized_url"],
+                    row["error_class"] or "unknown",
+                    row["finished_at"] or "unknown",
+                )
+                for row in recent_failures
+            ],
+        }
+
+    def get_global_admin_status(self) -> dict[str, Any]:
+        """Return owner-facing operational state across all chats."""
+        with self._lock:
+            cache_entries = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM recent_results",
+            ).fetchone()["count"]
+            queued = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM jobs WHERE status = 'queued'",
+            ).fetchone()["count"]
+            running = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM jobs WHERE status = 'running'",
+            ).fetchone()["count"]
+            failed_jobs = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM jobs WHERE status = 'failed'",
+            ).fetchone()["count"]
+            chats_with_jobs = self._conn.execute(
+                "SELECT COUNT(DISTINCT chat_id) AS count FROM jobs",
+            ).fetchone()["count"]
+            users_with_requests = self._conn.execute(
+                "SELECT COUNT(DISTINCT user_id) AS count FROM request_events",
+            ).fetchone()["count"]
+            duplicate_joins = self._conn.execute(
+                "SELECT COUNT(*) AS count FROM request_events WHERE joined_existing = 1",
+            ).fetchone()["count"]
+            provider_job_counts = self._conn.execute(
+                """
+                SELECT provider, status, COUNT(*) AS count
+                FROM jobs
+                GROUP BY provider, status
+                ORDER BY provider ASC, status ASC
+                """
+            ).fetchall()
+            recent_failures = self._conn.execute(
+                """
+                SELECT provider, normalized_url, error_class, finished_at
+                FROM jobs
+                WHERE status = 'failed'
+                ORDER BY finished_at DESC
+                LIMIT 5
+                """
+            ).fetchall()
+        return {
+            "cache_entries": int(cache_entries),
+            "queued_jobs": int(queued),
+            "running_jobs": int(running),
+            "failed_jobs": int(failed_jobs),
+            "chats_with_jobs": int(chats_with_jobs),
+            "users_with_requests": int(users_with_requests),
+            "duplicate_joins": int(duplicate_joins),
             "provider_job_counts": [
                 (row["provider"], row["status"], int(row["count"])) for row in provider_job_counts
             ],

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -9,7 +9,7 @@ import datetime as dtm
 import logging
 from pathlib import Path
 import time
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from telegram import InputMediaPhoto, InputMediaVideo, Message, Update
 from telegram.error import NetworkError, TelegramError
@@ -269,18 +269,16 @@ class TelegramBot:
             return
         snapshot = self.job_manager.get_snapshot(update.effective_chat.id)
         admin_status = self.state_store.get_admin_status(update.effective_chat.id)
+        performance = self._build_admin_performance_summary(
+            chat_id=update.effective_chat.id,
+            duplicate_joins=self.state_store.get_group_stats(update.effective_chat.id)["duplicate_joins"],
+            recent_failures=admin_status["recent_failures"],
+        )
         settings_row = admin_status["settings"]
         provider_lines = ", ".join(
             f"{provider}:{status}={count}"
             for provider, status, count in admin_status["provider_job_counts"]
         ) or "нет"
-        performance = self.state_store.get_performance_summary(update.effective_chat.id, limit=50)
-        group_stats = self.state_store.get_group_stats(update.effective_chat.id)
-        performance["duplicate_joins"] = group_stats["duplicate_joins"]
-        performance["failure_classes"] = list(performance.get("failure_classes", [])) + [
-            error_class
-            for _provider, _normalized_url, error_class, _finished_at in admin_status["recent_failures"]
-        ]
         failure_lines = "\n".join(
             f"  - {provider} | {error_class} | {normalized_url}"
             for provider, normalized_url, error_class, _finished_at in admin_status["recent_failures"]
@@ -298,6 +296,46 @@ class TelegramBot:
             f"- Выполняется задач: {admin_status['running_jobs']}\n"
             f"- В очереди задач: {admin_status['queued_jobs']}\n"
             f"- Активные запросы: {snapshot['active_requests']}\n"
+            f"- Ошибочных задач: {admin_status['failed_jobs']}\n"
+            f"- Записей в кэше: {admin_status['cache_entries']}\n"
+            f"- Кэш результатов: {self._ru_on_off(settings.RESULT_CACHE_ENABLED)}\n"
+            f"- Менеджер очереди: {self._ru_on_off(settings.QUEUE_MANAGER_ENABLED)}\n"
+            f"- Задачи по площадкам: {provider_lines}\n"
+            f"- Последние ошибки:\n{failure_lines}\n\n"
+            f"{self._format_performance_summary(performance)}"
+        )
+
+    async def admin_global_status_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Show owner-facing operational status across all chats."""
+        if not update.message:
+            return
+        if not await self._require_owner(update):
+            return
+        snapshot = self.job_manager.get_global_snapshot()
+        admin_status = self.state_store.get_global_admin_status()
+        performance = self._build_admin_performance_summary(
+            chat_id=None,
+            duplicate_joins=admin_status["duplicate_joins"],
+            recent_failures=admin_status["recent_failures"],
+        )
+        provider_lines = ", ".join(
+            f"{provider}:{status}={count}"
+            for provider, status, count in admin_status["provider_job_counts"]
+        ) or "нет"
+        failure_lines = "\n".join(
+            f"  - {provider} | {error_class} | {normalized_url}"
+            for provider, normalized_url, error_class, _finished_at in admin_status["recent_failures"]
+        ) or "  - нет"
+        uptime_seconds = int(time.time() - self.started_at)
+        await update.message.reply_text(
+            "Глобальный админ-статус:\n"
+            f"- Аптайм: {uptime_seconds}с\n"
+            f"- Чатов с задачами: {admin_status['chats_with_jobs']}\n"
+            f"- Пользователей с запросами: {admin_status['users_with_requests']}\n"
+            f"- Выполняется задач: {admin_status['running_jobs']}\n"
+            f"- В очереди задач: {admin_status['queued_jobs']}\n"
+            f"- Активные запросы: {snapshot['active_requests']}\n"
+            f"- Глобальный лимит: {snapshot['global_limit']}\n"
             f"- Ошибочных задач: {admin_status['failed_jobs']}\n"
             f"- Записей в кэше: {admin_status['cache_entries']}\n"
             f"- Кэш результатов: {self._ru_on_off(settings.RESULT_CACHE_ENABLED)}\n"
@@ -552,6 +590,21 @@ class TelegramBot:
             + (", ".join(failure_classes) if failure_classes else "нет")
         )
         return "\n".join(lines)
+
+    def _build_admin_performance_summary(
+        self,
+        *,
+        chat_id: int | None,
+        duplicate_joins: int,
+        recent_failures: list[tuple[str, str, str, str]],
+    ) -> dict[str, Any]:
+        performance = self.state_store.get_performance_summary(chat_id, limit=50)
+        performance["duplicate_joins"] = duplicate_joins
+        performance["failure_classes"] = list(performance.get("failure_classes", [])) + [
+            error_class
+            for _provider, _normalized_url, error_class, _finished_at in recent_failures
+        ]
+        return performance
 
     async def _on_job_state_change(self, job: SharedJob) -> None:
         """Propagate shared job state changes to per-request status messages."""
@@ -940,6 +993,7 @@ class TelegramBot:
         self.application.add_handler(CommandHandler("chatlimit", self.chatlimit_command))
         self.application.add_handler(CommandHandler("userlimit", self.userlimit_command))
         self.application.add_handler(CommandHandler("admin_status", self.admin_status_command))
+        self.application.add_handler(CommandHandler("admin_global_status", self.admin_global_status_command))
         self.application.add_handler(
             MessageHandler(
                 filters.TEXT & ~filters.COMMAND,

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -979,6 +979,50 @@ async def test_admin_status_includes_performance_summary(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_admin_global_status_reports_all_chats(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/admin_global_status", chat_id=77)
+    context = _FakeContext(_FakeBot())
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+    telegram_bot.state_store.create_job(
+        "job-current",
+        77,
+        "https://www.instagram.com/reel/current/",
+        "instagram",
+        "failed",
+    )
+    telegram_bot.state_store.create_job(
+        "job-other",
+        88,
+        "https://x.com/a/status/1",
+        "twitter",
+        "queued",
+    )
+
+    await telegram_bot.admin_global_status_command(update, context)
+
+    text = update.message.replies[-1]
+    assert "Глобальный админ-статус:" in text
+    assert "Чатов с задачами: 2" in text
+    assert "В очереди задач: 1" in text
+    assert "Ошибочных задач: 1" in text
+    assert "instagram:failed=1" in text
+    assert "twitter:queued=1" in text
+
+
+@pytest.mark.asyncio
+async def test_admin_global_status_requires_owner(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/admin_global_status", user_id=2002)
+    context = _FakeContext(_FakeBot())
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+
+    await telegram_bot.admin_global_status_command(update, context)
+
+    assert update.message.replies[-1] == "Эта команда доступна только владельцу бота."
+
+
+@pytest.mark.asyncio
 async def test_download_failure_records_provider_failure_class(monkeypatch, tmp_path):
     telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
     update = _FakeUpdate("https://www.instagram.com/reel/no-accounts/")


### PR DESCRIPTION
Adds /admin_global_status for all-chat/user status while keeping /admin_status scoped to the current chat. Both commands remain owner/admin-only.

Validation:
- .venv/bin/pytest tests/test_performance_metrics.py tests/test_job_manager.py tests/test_state_store_chaos.py tests/test_telegram_bot_media_send.py