### PR TITLE
[codex] Classify Instagram checkpoint failures

### DIFF
--- a/src/instagram_video_bot/services/instagram_client.py
+++ b/src/instagram_video_bot/services/instagram_client.py
@@ -44,6 +44,8 @@ class InstagramClient:
         )
         self.client = Client()
         self._session_settings: Optional[dict] = None
+        self.last_failure_class: Optional[str] = None
+        self.last_failure_reason: Optional[str] = None
         self._setup_proxy()
 
     def _redact_proxy(self, proxy: Optional[str]) -> str:
@@ -69,17 +71,45 @@ class InstagramClient:
             return "auth_challenge"
         if isinstance(error, LoginRequired) or "login_required" in error_str:
             return "auth_challenge"
+        if "login required" in error_str:
+            return "auth_challenge"
+        if (
+            "manual verification" in error_str
+            or "checkpoint" in error_str
+            or "ufac" in error_str
+            or "web bloks" in error_str
+        ):
+            return "auth_challenge"
         if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
             return "auth_challenge"
         if isinstance(error, PleaseWaitFewMinutes) or "please wait" in error_str:
             return "rate_limit"
         if "rate" in error_str and "limit" in error_str:
             return "rate_limit"
+        if (
+            "content isn't available to everyone" in error_str
+            or "certain audiences" in error_str
+            or "age-restricted" in error_str
+            or "age restricted" in error_str
+        ):
+            return "content_restricted"
         return "download_failed"
 
     def _is_auth_error(self, error: Exception) -> bool:
         """Whether this error should trigger auth recovery/rotation."""
         return self._classify_instagram_error(error) == "auth_challenge"
+
+    def _record_failure(self, error: Exception | str) -> str:
+        """Store the most specific recent provider failure for callers."""
+        if isinstance(error, Exception):
+            reason = str(error)
+            failure_class = self._classify_instagram_error(error)
+        else:
+            reason = error
+            failure_class = self._classify_instagram_error(Exception(error))
+        self.last_failure_class = failure_class
+        self.last_failure_reason = reason
+        return failure_class
 
     def _setup_proxy(self) -> None:
         """Configure proxy if available."""
@@ -182,6 +212,8 @@ class InstagramClient:
 
     def download_video(self, url: str, output_dir: Path) -> Optional[Path]:
         """Download video using instagrapi with validation error handling."""
+        self.last_failure_class = None
+        self.last_failure_reason = None
         try:
             # Extract media PK from URL
             media_pk = int(self.client.media_pk_from_url(url))
@@ -215,6 +247,7 @@ class InstagramClient:
                     return final_path
             except Exception as download_error:
                 failure_class = self._classify_instagram_error(download_error)
+                self._record_failure(download_error)
                 
                 # Check if this is a session expiration issue
                 if self._is_auth_error(download_error):
@@ -225,7 +258,9 @@ class InstagramClient:
                             video_path = self.client.video_download(media_pk, folder=output_dir)
                             logger.info(f"Video downloaded after re-login: {video_path}")
                             return video_path
-                        except Exception:
+                        except Exception as retry_error:
+                            if self._is_auth_error(retry_error):
+                                raise InstagramAuthError(str(retry_error)) from retry_error
                             logger.warning("Download still failed after re-login, trying fallbacks...")
                     else:
                         raise InstagramAuthError(str(download_error)) from download_error
@@ -253,6 +288,9 @@ class InstagramClient:
             raise
         except Exception as e:
             logger.error(f"Video download failed: {e}")
+            self._record_failure(e)
+            if self._is_auth_error(e):
+                raise InstagramAuthError(str(e)) from e
             return None
     
     def _get_media_dict_raw(self, media_pk: int) -> Optional[dict]:
@@ -547,6 +585,7 @@ class InstagramClient:
                 return output_file
             else:
                 if result.stderr:
+                    self._record_failure(result.stderr)
                     logger.warning(f"yt-dlp failed: {result.stderr}")
                 if output_file.exists():
                     output_file.unlink()

--- a/src/instagram_video_bot/services/instagram_client.py
+++ b/src/instagram_video_bot/services/instagram_client.py
@@ -80,12 +80,6 @@ class InstagramClient:
             or "web bloks" in error_str
         ):
             return "auth_challenge"
-        if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
-            return "auth_challenge"
-        if isinstance(error, PleaseWaitFewMinutes) or "please wait" in error_str:
-            return "rate_limit"
-        if "rate" in error_str and "limit" in error_str:
-            return "rate_limit"
         if (
             "content isn't available to everyone" in error_str
             or "certain audiences" in error_str
@@ -93,6 +87,12 @@ class InstagramClient:
             or "age restricted" in error_str
         ):
             return "content_restricted"
+        if "401" in error_str or "403" in error_str or "unauthorized" in error_str:
+            return "auth_challenge"
+        if isinstance(error, PleaseWaitFewMinutes) or "please wait" in error_str:
+            return "rate_limit"
+        if "rate" in error_str and "limit" in error_str:
+            return "rate_limit"
         return "download_failed"
 
     def _is_auth_error(self, error: Exception) -> bool:

--- a/src/instagram_video_bot/services/instagram_client.py
+++ b/src/instagram_video_bot/services/instagram_client.py
@@ -234,6 +234,9 @@ class InstagramClient:
                     },
                 )
                 return video_path
+            if self.last_failure_class == "auth_challenge":
+                self.last_failure_class = None
+                self.last_failure_reason = None
             
             try:
                 # Try the standard video_download without folder first (like in the example)

--- a/src/instagram_video_bot/services/provider_adapters.py
+++ b/src/instagram_video_bot/services/provider_adapters.py
@@ -108,6 +108,12 @@ class InstagramProviderAdapter:
 
         file_path = self._download_with_legacy_client(client, url, output_dir)
         if not file_path:
+            failure_class = getattr(client, "last_failure_class", None)
+            if failure_class == "auth_challenge":
+                reason = getattr(client, "last_failure_reason", None) or failure_class
+                raise InstagramAuthError(str(reason))
+            if failure_class and failure_class != "download_failed":
+                raise DownloadError(f"Instagram download failed: {failure_class}")
             raise DownloadError("Failed to download video")
 
         media_info = {"title": "", "duration": 0}

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -250,7 +250,7 @@ class VideoDownloader:
                     self.last_account_health_event = event
             except Exception as error:
                 if isinstance(error, DownloadError):
-                    self.last_provider_metrics.failure_class = "download_failed"
+                    self.last_provider_metrics.failure_class = self._classify_instagram_fallback_error(error)
                     raise
                 last_error = error
                 self.last_provider_metrics.failure_class = "download_failed"
@@ -311,7 +311,7 @@ class VideoDownloader:
                 )
             except Exception as error:
                 if isinstance(error, DownloadError):
-                    self.last_provider_metrics.failure_class = "download_failed"
+                    self.last_provider_metrics.failure_class = self._classify_instagram_fallback_error(error)
                     raise
                 last_error = error
                 self.last_provider_metrics.failure_class = "download_failed"
@@ -359,6 +359,14 @@ class VideoDownloader:
     @staticmethod
     def _classify_download_error(error: Exception) -> str:
         text = str(error).lower()
+        if (
+            "content_restricted" in text
+            or "content isn't available to everyone" in text
+            or "certain audiences" in text
+            or "age-restricted" in text
+            or "age restricted" in text
+        ):
+            return "content_restricted"
         if "unsupported" in text:
             return "unsupported_url"
         if "timeout" in text or "timed out" in text:
@@ -371,6 +379,11 @@ class VideoDownloader:
         ):
             return "transient_network"
         return "unknown"
+
+    @classmethod
+    def _classify_instagram_fallback_error(cls, error: Exception) -> str:
+        failure_class = cls._classify_download_error(error)
+        return "download_failed" if failure_class == "unknown" else failure_class
 
     @staticmethod
     def _is_twitter_url(url: str) -> bool:

--- a/tests/test_instagram_client_metadata.py
+++ b/tests/test_instagram_client_metadata.py
@@ -1,4 +1,6 @@
-from src.instagram_video_bot.services.instagram_client import InstagramClient
+import pytest
+
+from src.instagram_video_bot.services.instagram_client import InstagramAuthError, InstagramClient
 
 
 class _FailingMediaAPIClient:
@@ -10,6 +12,19 @@ class _FailingMediaAPIClient:
 
     def media_info_v1(self, _media_pk: int):
         raise Exception("media info v1 failed")
+
+
+class _CheckpointDownloadClient:
+    user_agent = "test-agent"
+
+    def media_pk_from_url(self, _url: str) -> int:
+        return 123456
+
+    def video_download(self, _media_pk: int, folder=None):
+        raise Exception(
+            "Manual verification required via Instagram UFAC web bloks checkpoint. "
+            "Please resolve it in the Instagram app or web flow and then retry."
+        )
 
 
 def test_get_media_info_returns_minimal_fallback_when_all_lookups_fail():
@@ -24,3 +39,19 @@ def test_get_media_info_returns_minimal_fallback_when_all_lookups_fail():
     assert info["title"] == ""
     assert info["duration"] == 0
     assert info["user"] == "unknown"
+
+
+def test_checkpoint_manual_verification_is_auth_challenge():
+    error = Exception("Manual verification required via Instagram UFAC web bloks checkpoint")
+
+    assert InstagramClient._classify_instagram_error(error) == "auth_challenge"
+
+
+def test_download_video_propagates_checkpoint_after_relogin_attempt(monkeypatch, tmp_path):
+    client = InstagramClient(username="u", password="p")
+    client.client = _CheckpointDownloadClient()
+    client._download_with_ytdlp_first = lambda *_args: None
+    client._relogin = lambda: True
+
+    with pytest.raises(InstagramAuthError, match="Manual verification required"):
+        client.download_video("https://www.instagram.com/reel/test/", tmp_path)

--- a/tests/test_instagram_client_metadata.py
+++ b/tests/test_instagram_client_metadata.py
@@ -27,6 +27,16 @@ class _CheckpointDownloadClient:
         )
 
 
+class _MissingVideoDownloadClient:
+    user_agent = "test-agent"
+
+    def media_pk_from_url(self, _url: str) -> int:
+        return 123456
+
+    def video_download(self, _media_pk: int, folder=None):
+        return None
+
+
 def test_get_media_info_returns_minimal_fallback_when_all_lookups_fail():
     client = InstagramClient(username="u", password="p")
     client.client = _FailingMediaAPIClient()
@@ -61,3 +71,17 @@ def test_download_video_propagates_checkpoint_after_relogin_attempt(monkeypatch,
 
     with pytest.raises(InstagramAuthError, match="Manual verification required"):
         client.download_video("https://www.instagram.com/reel/test/", tmp_path)
+
+
+def test_initial_ytdlp_403_does_not_stick_when_authenticated_download_returns_no_file(tmp_path):
+    client = InstagramClient(username="u", password="p")
+    client.client = _MissingVideoDownloadClient()
+
+    def _failed_ytdlp(*_args):
+        client._record_failure("ERROR: 403 Forbidden")
+        return None
+
+    client._download_with_ytdlp_first = _failed_ytdlp
+
+    assert client.download_video("https://www.instagram.com/reel/test/", tmp_path) is None
+    assert client.last_failure_class != "auth_challenge"

--- a/tests/test_instagram_client_metadata.py
+++ b/tests/test_instagram_client_metadata.py
@@ -47,6 +47,12 @@ def test_checkpoint_manual_verification_is_auth_challenge():
     assert InstagramClient._classify_instagram_error(error) == "auth_challenge"
 
 
+def test_content_restriction_with_403_is_not_auth_challenge():
+    error = Exception("403 This content isn't available to everyone")
+
+    assert InstagramClient._classify_instagram_error(error) == "content_restricted"
+
+
 def test_download_video_propagates_checkpoint_after_relogin_attempt(monkeypatch, tmp_path):
     client = InstagramClient(username="u", password="p")
     client.client = _CheckpointDownloadClient()

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -75,6 +75,44 @@ class _DownloadErrorClient:
         return None
 
 
+class _ContentRestrictedClient:
+    username = "acc_restricted"
+    proxy = None
+    last_failure_class = "content_restricted"
+    last_failure_reason = "This content isn't available to everyone"
+
+    def login(self):
+        return True
+
+    def download_video(self, _url: str, _output_dir: Path):
+        return None
+
+    def download_media(self, _url: str, _output_dir: Path):
+        return None
+
+    def get_media_info(self, _url: str):
+        return None
+
+
+class _AuthChallengeResultClient:
+    username = "acc_challenge"
+    proxy = None
+    last_failure_class = "auth_challenge"
+    last_failure_reason = "login required"
+
+    def login(self):
+        return True
+
+    def download_video(self, _url: str, _output_dir: Path):
+        return None
+
+    def download_media(self, _url: str, _output_dir: Path):
+        return None
+
+    def get_media_info(self, _url: str):
+        return None
+
+
 class _FastExtractorSuccess:
     def __init__(self, path: Path, media_type: str = "video"):
         self._path = path
@@ -753,6 +791,61 @@ async def test_single_account_download_error_sets_failure_class(monkeypatch, tmp
     assert metrics.instagram_account_retries == 0
     assert metrics.retry_count == 0
     assert metrics.failure_class == "download_failed"
+
+
+@pytest.mark.asyncio
+async def test_leased_content_restriction_is_not_recorded_as_account_failure(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    manager = _LeaseManager([_Account("acc_restricted")])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.video_downloader.InstagramClient",
+        lambda **_kwargs: _ContentRestrictedClient(),
+    )
+
+    with pytest.raises(DownloadError, match="content_restricted"):
+        await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    metrics = downloader.last_provider_metrics
+    assert metrics.instagram_account_attempts == 1
+    assert metrics.instagram_auth_failures == 0
+    assert metrics.failure_class == "content_restricted"
+    assert manager.failures == []
+
+
+@pytest.mark.asyncio
+async def test_leased_auth_challenge_failure_class_rotates_account(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "after-auth-challenge.mp4"
+    expected_path.write_bytes(b"video")
+
+    manager = _LeaseManager([_Account("acc_challenge"), _Account("acc_ok")])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_challenge": _AuthChallengeResultClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.video_downloader.InstagramClient",
+        lambda **kwargs: clients[kwargs["username"]],
+    )
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert downloader.last_provider_metrics.instagram_auth_failures == 1
+    assert downloader.last_provider_metrics.failure_class == "auth_challenge"
+    assert manager.failures == [("acc_challenge", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- classify Instagram checkpoint/manual-verification/login-required failures as auth challenges
- propagate auth-classified no-file fallback results into account rotation
- preserve content restriction failures separately from account health failures
- add regression coverage for checkpoint propagation, rotation, and content restrictions

## Validation
- env UV_CACHE_DIR=/tmp/uv-cache STATE_DB_PATH=/tmp/codex-bot-state.sqlite3 uv run --no-sync pytest

Fixes #18