### PR TITLE
Fix Instagram post fallback downloads

### DIFF
--- a/src/instagram_video_bot/services/instagram_client.py
+++ b/src/instagram_video_bot/services/instagram_client.py
@@ -156,11 +156,161 @@ class InstagramClient:
 
         return False
 
-    def download_media(self, url: str, output_dir: Path) -> Optional[Path]:
-        """Download media by URL, including authenticated story handling."""
+    def download_media(self, url: str, output_dir: Path) -> Optional[Path | list[Path]]:
+        """Download media by URL, including authenticated story/post handling."""
         if "/stories/" in url.lower():
             return self._download_story_media(url, output_dir)
-        return self.download_video(url, output_dir)
+        return self._download_post_media(url, output_dir)
+
+    def _download_post_media(self, url: str, output_dir: Path) -> Optional[Path | list[Path]]:
+        """Download a regular post, preserving photo posts and carousel albums."""
+        self.last_failure_class = None
+        self.last_failure_reason = None
+
+        try:
+            media_pk = int(self.client.media_pk_from_url(url))
+            output_dir.mkdir(parents=True, exist_ok=True)
+            raw_item = self._get_media_dict_raw(media_pk) or {}
+            media_type = self._safe_int(raw_item.get("media_type"))
+
+            if media_type == 8 or raw_item.get("carousel_media"):
+                album_paths = self._download_album_media(media_pk, raw_item, output_dir)
+                if album_paths:
+                    return album_paths
+                return None
+
+            if media_type == 1:
+                photo_path = self._download_photo_media(media_pk, raw_item, output_dir)
+                if photo_path:
+                    return photo_path
+                return None
+
+            return self.download_video(url, output_dir)
+
+        except InstagramAuthError:
+            raise
+        except Exception as error:
+            logger.error(f"Post media download failed: {error}")
+            self._record_failure(error)
+            if self._is_auth_error(error):
+                raise InstagramAuthError(str(error)) from error
+            return None
+
+    def _download_album_media(
+        self,
+        media_pk: int,
+        raw_item: dict,
+        output_dir: Path,
+    ) -> Optional[list[Path]]:
+        """Download all resources from a carousel post."""
+        try:
+            paths = self.client.album_download(media_pk, folder=output_dir)
+            if paths:
+                logger.info(f"Album downloaded: {paths}")
+                return paths
+        except Exception as album_error:
+            if self._is_auth_error(album_error):
+                logger.warning("Session expired during album download, attempting re-login...")
+                if not self._relogin():
+                    raise InstagramAuthError(str(album_error)) from album_error
+                try:
+                    paths = self.client.album_download(media_pk, folder=output_dir)
+                    if paths:
+                        logger.info(f"Album downloaded after re-login: {paths}")
+                        return paths
+                except Exception as retry_error:
+                    if self._is_auth_error(retry_error):
+                        raise InstagramAuthError(str(retry_error)) from retry_error
+                    logger.warning(f"Album download retry failed: {retry_error}")
+            else:
+                logger.warning(f"Album download failed: {album_error}")
+
+        return self._download_album_from_raw_item(media_pk, raw_item, output_dir)
+
+    def _download_photo_media(
+        self,
+        media_pk: int,
+        raw_item: dict,
+        output_dir: Path,
+    ) -> Optional[Path]:
+        """Download a single photo post."""
+        try:
+            photo_path = self.client.photo_download(media_pk, folder=output_dir)
+            if photo_path and photo_path.exists():
+                logger.info(f"Photo downloaded: {photo_path}")
+                return photo_path
+        except Exception as photo_error:
+            if self._is_auth_error(photo_error):
+                logger.warning("Session expired during photo download, attempting re-login...")
+                if not self._relogin():
+                    raise InstagramAuthError(str(photo_error)) from photo_error
+                try:
+                    photo_path = self.client.photo_download(media_pk, folder=output_dir)
+                    if photo_path and photo_path.exists():
+                        logger.info(f"Photo downloaded after re-login: {photo_path}")
+                        return photo_path
+                except Exception as retry_error:
+                    if self._is_auth_error(retry_error):
+                        raise InstagramAuthError(str(retry_error)) from retry_error
+                    logger.warning(f"Photo download retry failed: {retry_error}")
+            else:
+                logger.warning(f"Photo download failed: {photo_error}")
+
+        image_url = self._pick_image_url(raw_item)
+        if not image_url:
+            return None
+        try:
+            return self.client.photo_download_by_url(
+                image_url,
+                f"photo_{media_pk}",
+                output_dir,
+            )
+        except Exception as raw_error:
+            logger.warning(f"Raw photo URL download failed: {raw_error}")
+            self._record_failure(raw_error)
+            return None
+
+    def _download_album_from_raw_item(
+        self,
+        media_pk: int,
+        raw_item: dict,
+        output_dir: Path,
+    ) -> Optional[list[Path]]:
+        """Download carousel resources from raw mobile API payload."""
+        carousel = raw_item.get("carousel_media")
+        if not isinstance(carousel, list) or not carousel:
+            return None
+
+        paths: list[Path] = []
+        for index, resource in enumerate(carousel, start=1):
+            if not isinstance(resource, dict):
+                continue
+            try:
+                video_url = self._pick_video_url(resource)
+                if video_url:
+                    path = self.client.video_download_by_url(
+                        video_url,
+                        f"album_{media_pk}_{index}",
+                        output_dir,
+                    )
+                else:
+                    image_url = self._pick_image_url(resource)
+                    if not image_url:
+                        continue
+                    path = self.client.photo_download_by_url(
+                        image_url,
+                        f"album_{media_pk}_{index}",
+                        output_dir,
+                    )
+                if path and path.exists():
+                    paths.append(path)
+            except Exception as raw_error:
+                logger.warning(f"Raw carousel item {index} download failed: {raw_error}")
+
+        if paths:
+            logger.info(f"Album downloaded from raw item: {paths}")
+            return paths
+        return None
 
     def _download_story_media(self, url: str, output_dir: Path) -> Optional[Path]:
         """Download Instagram story media using authenticated instagrapi APIs."""
@@ -317,6 +467,62 @@ class InstagramClient:
         except Exception as e:
             logger.warning(f"Failed to get raw media dict: {e}")
             return None
+
+    @staticmethod
+    def _safe_int(value) -> Optional[int]:
+        """Convert an Instagram payload value to int when possible."""
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _pick_video_url(item: dict) -> Optional[str]:
+        """Pick the best direct video URL from a raw media item."""
+        video_versions = item.get("video_versions")
+        if isinstance(video_versions, list) and video_versions:
+            candidates = [
+                candidate
+                for candidate in video_versions
+                if isinstance(candidate, dict) and candidate.get("url")
+            ]
+            if candidates:
+                best = max(
+                    candidates,
+                    key=lambda candidate: int(candidate.get("width") or 0)
+                    * int(candidate.get("height") or 0),
+                )
+                return str(best["url"])
+        video_url = item.get("video_url")
+        if video_url:
+            return str(video_url)
+        return None
+
+    @staticmethod
+    def _pick_image_url(item: dict) -> Optional[str]:
+        """Pick the best direct image URL from a raw media item."""
+        image_versions = item.get("image_versions2")
+        if isinstance(image_versions, dict):
+            candidates = image_versions.get("candidates")
+            if isinstance(candidates, list) and candidates:
+                parsed_candidates = [
+                    candidate
+                    for candidate in candidates
+                    if isinstance(candidate, dict) and candidate.get("url")
+                ]
+                if parsed_candidates:
+                    best = max(
+                        parsed_candidates,
+                        key=lambda candidate: int(candidate.get("width") or 0)
+                        * int(candidate.get("height") or 0),
+                    )
+                    return str(best["url"])
+        thumbnail_url = item.get("thumbnail_url")
+        if thumbnail_url:
+            return str(thumbnail_url)
+        return None
     
     def _get_video_url_raw(self, media_pk: int) -> Optional[str]:
         """Get video URL from raw API data, bypassing Pydantic validation."""

--- a/src/instagram_video_bot/services/provider_adapters.py
+++ b/src/instagram_video_bot/services/provider_adapters.py
@@ -106,8 +106,8 @@ class InstagramProviderAdapter:
             },
         )
 
-        file_path = self._download_with_legacy_client(client, url, output_dir)
-        if not file_path:
+        downloaded_paths = self._download_with_legacy_client(client, url, output_dir)
+        if not downloaded_paths:
             failure_class = getattr(client, "last_failure_class", None)
             if failure_class == "auth_challenge":
                 reason = getattr(client, "last_failure_reason", None) or failure_class
@@ -115,6 +115,11 @@ class InstagramProviderAdapter:
             if failure_class and failure_class != "download_failed":
                 raise DownloadError(f"Instagram download failed: {failure_class}")
             raise DownloadError("Failed to download video")
+
+        if isinstance(downloaded_paths, list):
+            file_paths = downloaded_paths
+        else:
+            file_paths = [downloaded_paths]
 
         media_info = {"title": "", "duration": 0}
         try:
@@ -140,20 +145,25 @@ class InstagramProviderAdapter:
                 },
             )
 
-        media_type = self._infer_media_type(file_path)
-        media_item = self._build_media_item(
-            file_path=file_path,
-            media_type=media_type,
-            caption=media_info.get("title") or None,
-            duration=media_info.get("duration"),
-        )
+        media_items = []
+        for file_path in file_paths:
+            media_type = self._infer_media_type(file_path)
+            media_items.append(
+                self._build_media_item(
+                    file_path=file_path,
+                    media_type=media_type,
+                    caption=media_info.get("title") or None,
+                    duration=media_info.get("duration"),
+                )
+            )
+        primary_item = media_items[0]
         return VideoInfo(
-            file_path=file_path,
+            file_path=primary_item.file_path,
             title=media_info.get("title", ""),
-            duration=media_item.duration,
+            duration=primary_item.duration,
             description=media_info.get("title", ""),
-            media_items=[media_item],
-            primary_media_type=media_type,
+            media_items=media_items,
+            primary_media_type=primary_item.media_type,
         )
 
     def is_story_url(self, url: str) -> bool:
@@ -163,7 +173,7 @@ class InstagramProviderAdapter:
     @staticmethod
     def _download_with_legacy_client(
         client: InstagramClient, url: str, output_dir: Path
-    ) -> Optional[Path]:
+    ) -> Optional[Path | list[Path]]:
         """Download media using existing authenticated client path."""
         if hasattr(client, "download_media"):
             return client.download_media(url, output_dir)

--- a/tests/test_instagram_client_metadata.py
+++ b/tests/test_instagram_client_metadata.py
@@ -37,6 +37,64 @@ class _MissingVideoDownloadClient:
         return None
 
 
+class _PhotoPostClient:
+    def __init__(self, photo_path):
+        self.photo_path = photo_path
+
+    def media_pk_from_url(self, _url: str) -> int:
+        return 123456
+
+    def private_request(self, _endpoint: str):
+        return {"items": [{"media_type": 1}]}
+
+    def photo_download(self, _media_pk: int, folder=None):
+        return self.photo_path
+
+
+class _CarouselPostClient:
+    def __init__(self, output_dir):
+        self.output_dir = output_dir
+
+    def media_pk_from_url(self, _url: str) -> int:
+        return 123456
+
+    def private_request(self, _endpoint: str):
+        return {
+            "items": [
+                {
+                    "media_type": 8,
+                    "carousel_media": [
+                        {
+                            "image_versions2": {
+                                "candidates": [
+                                    {"url": "https://cdn.example.com/one.jpg", "width": 720, "height": 720}
+                                ]
+                            }
+                        },
+                        {
+                            "video_versions": [
+                                {"url": "https://cdn.example.com/two.mp4", "width": 1080, "height": 1920}
+                            ]
+                        },
+                    ],
+                }
+            ]
+        }
+
+    def album_download(self, _media_pk: int, folder=None):
+        raise Exception("album validation failed")
+
+    def photo_download_by_url(self, _url: str, filename: str, folder=None):
+        path = self.output_dir / f"{filename}.jpg"
+        path.write_bytes(b"photo")
+        return path
+
+    def video_download_by_url(self, _url: str, filename: str, folder=None):
+        path = self.output_dir / f"{filename}.mp4"
+        path.write_bytes(b"video")
+        return path
+
+
 def test_get_media_info_returns_minimal_fallback_when_all_lookups_fail():
     client = InstagramClient(username="u", password="p")
     client.client = _FailingMediaAPIClient()
@@ -85,3 +143,22 @@ def test_initial_ytdlp_403_does_not_stick_when_authenticated_download_returns_no
 
     assert client.download_video("https://www.instagram.com/reel/test/", tmp_path) is None
     assert client.last_failure_class != "auth_challenge"
+
+
+def test_download_media_uses_photo_download_for_photo_posts(tmp_path):
+    photo_path = tmp_path / "photo.jpg"
+    photo_path.write_bytes(b"photo")
+    client = InstagramClient(username="u", password="p")
+    client.client = _PhotoPostClient(photo_path)
+
+    assert client.download_media("https://www.instagram.com/p/photo/", tmp_path) == photo_path
+
+
+def test_download_media_preserves_carousel_items_from_raw_payload(tmp_path):
+    client = InstagramClient(username="u", password="p")
+    client.client = _CarouselPostClient(tmp_path)
+
+    paths = client.download_media("https://www.instagram.com/p/album/", tmp_path)
+
+    assert isinstance(paths, list)
+    assert [path.suffix for path in paths] == [".jpg", ".mp4"]

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -268,6 +268,37 @@ def test_build_media_item_treats_zero_duration_as_missing(monkeypatch, tmp_path)
     assert media_item.height == 1280
 
 
+def test_instagram_adapter_maps_legacy_album_paths_to_media_items(tmp_path):
+    first = tmp_path / "one.jpg"
+    second = tmp_path / "two.png"
+    first.write_bytes(b"photo")
+    second.write_bytes(b"photo")
+
+    class _AlbumClient:
+        username = "acc_album"
+        proxy = None
+
+        def download_media(self, _url: str, _output_dir: Path):
+            return [first, second]
+
+        def get_media_info(self, _url: str):
+            return {"title": "album caption", "duration": 0}
+
+    adapter = InstagramProviderAdapter(fast_extractor=None)
+
+    info = adapter.download_with_instagram_client(
+        client=_AlbumClient(),
+        url="https://www.instagram.com/p/album/",
+        output_dir=tmp_path,
+        redact_proxy=lambda proxy: proxy,
+    )
+
+    assert info.file_path == first
+    assert info.primary_media_type == "photo"
+    assert [item.file_path for item in info.media_items] == [first, second]
+    assert [item.media_type for item in info.media_items] == ["photo", "photo"]
+
+
 @pytest.mark.asyncio
 async def test_instagram_fallback_waits_for_leased_account(monkeypatch, tmp_path):
     downloader = VideoDownloader()


### PR DESCRIPTION
## Summary
- preserve authenticated fallback support for Instagram /p/ photo posts and carousels
- map fallback album paths into multiple Telegram media items
- add tests for photo, carousel, and adapter album handling

## Tests
- .venv/bin/pytest tests/test_instagram_client_metadata.py tests/test_video_downloader_flow.py tests/test_instagram_fast_extractor.py tests/test_request_parser.py