### PR TITLE
Improve bot reliability metrics

### DIFF
--- a/src/instagram_video_bot/__main__.py
+++ b/src/instagram_video_bot/__main__.py
@@ -21,7 +21,9 @@ def setup_logging() -> None:
     # Set external loggers to WARNING level
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("telegram").setLevel(logging.WARNING)
-    logging.getLogger("instagrapi").setLevel(logging.INFO)  # Add instagrapi logging
+    logging.getLogger("instagrapi").setLevel(logging.WARNING)
+    logging.getLogger("private_request").setLevel(logging.WARNING)
+    logging.getLogger("public_request").setLevel(logging.WARNING)
 
 def check_environment() -> None:
     """Verify that all required environment variables exist."""

--- a/src/instagram_video_bot/services/job_manager.py
+++ b/src/instagram_video_bot/services/job_manager.py
@@ -79,6 +79,12 @@ class JobManager:
         self._jobs: dict[str, SharedJob] = {}
         self._active_jobs: dict[tuple[int, str], SharedJob] = {}
         self._listeners: list[StateListener] = []
+        interrupted = self.store.reconcile_interrupted_jobs()
+        if interrupted:
+            logger.warning(
+                "Reconciled interrupted persisted jobs",
+                extra={"interrupted_jobs": interrupted, "failure_class": "process_restarted"},
+            )
 
     def add_state_listener(self, listener: StateListener) -> None:
         self._listeners.append(listener)

--- a/src/instagram_video_bot/services/state_store.py
+++ b/src/instagram_video_bot/services/state_store.py
@@ -35,7 +35,7 @@ class StateStore:
 
     def __init__(self, db_path: Path | None = None):
         self.db_path = db_path or settings.STATE_DB_PATH
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         self._initialize()
@@ -235,6 +235,109 @@ class StateStore:
             "chat_max_concurrent_jobs": settings_row["chat_max_concurrent_jobs"],
             "user_max_active_jobs": settings_row["user_max_active_jobs"],
         }
+
+    def reconcile_interrupted_jobs(self, *, reason: str = "process_restarted") -> int:
+        """Cancel persisted active jobs that cannot survive a process restart."""
+        now = _utc_now().isoformat()
+        active_statuses = ("queued", "running")
+        with self._lock, self._conn:
+            cursor = self._conn.execute(
+                """
+                UPDATE jobs
+                SET status = 'cancelled',
+                    error_class = COALESCE(error_class, ?),
+                    finished_at = COALESCE(finished_at, ?)
+                WHERE status IN (?, ?)
+                """,
+                (reason, now, *active_statuses),
+            )
+            interrupted_count = cursor.rowcount
+            self._conn.execute(
+                """
+                UPDATE request_events
+                SET status = 'cancelled',
+                    updated_at = ?
+                WHERE status IN (?, ?)
+                """,
+                (now, *active_statuses),
+            )
+            self._conn.execute(
+                """
+                UPDATE performance_metrics
+                SET status = 'cancelled',
+                    failure_class = COALESCE(failure_class, ?),
+                    finished_at = COALESCE(finished_at, ?)
+                WHERE status IN (?, ?)
+                """,
+                (reason, now, *active_statuses),
+            )
+        return int(interrupted_count)
+
+    def get_stale_active_job_count(
+        self,
+        *,
+        older_than_seconds: float,
+        chat_id: int | None = None,
+    ) -> int:
+        """Return active persisted jobs older than the allowed runtime window."""
+        cutoff = (_utc_now() - timedelta(seconds=max(0.0, older_than_seconds))).isoformat()
+        with self._lock:
+            if chat_id is None:
+                row = self._conn.execute(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM jobs
+                    WHERE status = 'running'
+                      AND COALESCE(started_at, created_at) < ?
+                    """,
+                    (cutoff,),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM jobs
+                    WHERE chat_id = ?
+                      AND status = 'running'
+                      AND COALESCE(started_at, created_at) < ?
+                    """,
+                    (chat_id, cutoff),
+                ).fetchone()
+        return int(row["count"] or 0)
+
+    def get_recent_provider_timeout_count(
+        self,
+        *,
+        chat_id: int | None = None,
+        window_seconds: float = 60 * 60,
+    ) -> int:
+        """Return recent provider timeout failures from performance metrics."""
+        cutoff = (_utc_now() - timedelta(seconds=max(0.0, window_seconds))).isoformat()
+        with self._lock:
+            if chat_id is None:
+                row = self._conn.execute(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM performance_metrics
+                    WHERE status = 'failed'
+                      AND failure_class = 'provider_timeout'
+                      AND finished_at >= ?
+                    """,
+                    (cutoff,),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM performance_metrics
+                    WHERE chat_id = ?
+                      AND status = 'failed'
+                      AND failure_class = 'provider_timeout'
+                      AND finished_at >= ?
+                    """,
+                    (chat_id, cutoff),
+                ).fetchone()
+        return int(row["count"] or 0)
 
     def create_job(self, job_id: str, chat_id: int, normalized_url: str, provider: str, status: str) -> None:
         now = _utc_now().isoformat()
@@ -716,6 +819,11 @@ class StateStore:
             "cache_entries": int(cache_entries),
             "queued_jobs": int(queued),
             "running_jobs": int(running),
+            "stale_active_jobs": self.get_stale_active_job_count(
+                older_than_seconds=settings.INSTAGRAM_PROVIDER_TIMEOUT_SECONDS * 2,
+                chat_id=chat_id,
+            ),
+            "recent_provider_timeouts": self.get_recent_provider_timeout_count(chat_id=chat_id),
             "failed_jobs": int(failed_jobs),
             "provider_job_counts": [
                 (row["provider"], row["status"], int(row["count"])) for row in provider_job_counts
@@ -776,6 +884,10 @@ class StateStore:
             "cache_entries": int(cache_entries),
             "queued_jobs": int(queued),
             "running_jobs": int(running),
+            "stale_active_jobs": self.get_stale_active_job_count(
+                older_than_seconds=settings.INSTAGRAM_PROVIDER_TIMEOUT_SECONDS * 2
+            ),
+            "recent_provider_timeouts": self.get_recent_provider_timeout_count(),
             "failed_jobs": int(failed_jobs),
             "chats_with_jobs": int(chats_with_jobs),
             "users_with_requests": int(users_with_requests),

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -55,6 +55,7 @@ class TelegramBot:
 
     INSTAGRAM_VIDEO_PATTERN = RequestParser.URL_PATTERN
     MAX_MEDIA_CAPTION_LENGTH = 1024
+    TELEGRAM_MEDIA_GROUP_LIMIT = 10
 
     def __init__(self, state_store: StateStore | None = None):
         self.application: Optional[Application] = None
@@ -295,6 +296,8 @@ class TelegramBot:
             f"- Лимит на пользователя: {settings_row['user_max_active_jobs']}\n"
             f"- Выполняется задач: {admin_status['running_jobs']}\n"
             f"- В очереди задач: {admin_status['queued_jobs']}\n"
+            f"- Зависших активных задач: {admin_status['stale_active_jobs']}\n"
+            f"- Provider timeout за час: {admin_status['recent_provider_timeouts']}\n"
             f"- Активные запросы: {snapshot['active_requests']}\n"
             f"- Ошибочных задач: {admin_status['failed_jobs']}\n"
             f"- Записей в кэше: {admin_status['cache_entries']}\n"
@@ -334,6 +337,8 @@ class TelegramBot:
             f"- Пользователей с запросами: {admin_status['users_with_requests']}\n"
             f"- Выполняется задач: {admin_status['running_jobs']}\n"
             f"- В очереди задач: {admin_status['queued_jobs']}\n"
+            f"- Зависших активных задач: {admin_status['stale_active_jobs']}\n"
+            f"- Provider timeout за час: {admin_status['recent_provider_timeouts']}\n"
             f"- Активные запросы: {snapshot['active_requests']}\n"
             f"- Глобальный лимит: {snapshot['global_limit']}\n"
             f"- Ошибочных задач: {admin_status['failed_jobs']}\n"
@@ -672,25 +677,64 @@ class TelegramBot:
 
         if len(media_items) == 1:
             media_item = media_items[0]
-            with open(media_item.file_path, "rb") as media_file:
-                if media_item.media_type == "video":
-                    video_kwargs = self._telegram_video_kwargs(media_item)
-                    await context.bot.send_video(
-                        chat_id=request_context.chat_id,
-                        video=media_file,
-                        caption=caption_text,
-                        reply_to_message_id=request_context.original_message_id,
-                        **video_kwargs,
-                    )
-                else:
-                    await context.bot.send_photo(
-                        chat_id=request_context.chat_id,
-                        photo=media_file,
-                        caption=caption_text,
-                        reply_to_message_id=request_context.original_message_id,
-                    )
+            await self._send_single_media_item(
+                context,
+                request_context,
+                media_item,
+                caption_text,
+            )
             return
 
+        caption_available = caption_text
+        for offset in range(0, len(media_items), self.TELEGRAM_MEDIA_GROUP_LIMIT):
+            chunk = media_items[offset : offset + self.TELEGRAM_MEDIA_GROUP_LIMIT]
+            chunk_caption = caption_available if offset == 0 else None
+            if len(chunk) == 1:
+                await self._send_single_media_item(
+                    context,
+                    request_context,
+                    chunk[0],
+                    chunk_caption,
+                )
+            else:
+                await self._send_media_group_chunk(
+                    context,
+                    request_context,
+                    chunk,
+                    chunk_caption,
+                )
+
+    async def _send_single_media_item(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        request_context: RequestContext,
+        media_item: MediaItem,
+        caption_text: str | None,
+    ) -> None:
+        with open(media_item.file_path, "rb") as media_file:
+            if media_item.media_type == "video":
+                await context.bot.send_video(
+                    chat_id=request_context.chat_id,
+                    video=media_file,
+                    caption=caption_text,
+                    reply_to_message_id=request_context.original_message_id,
+                    **self._telegram_video_kwargs(media_item),
+                )
+            else:
+                await context.bot.send_photo(
+                    chat_id=request_context.chat_id,
+                    photo=media_file,
+                    caption=caption_text,
+                    reply_to_message_id=request_context.original_message_id,
+                )
+
+    async def _send_media_group_chunk(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        request_context: RequestContext,
+        media_items: list[MediaItem],
+        caption_text: str | None,
+    ) -> None:
         with ExitStack() as stack:
             media_group = []
             for index, media_item in enumerate(media_items):
@@ -706,7 +750,6 @@ class TelegramBot:
                     )
                 else:
                     media_group.append(InputMediaPhoto(media=media_file, caption=item_caption))
-
             await context.bot.send_media_group(
                 chat_id=request_context.chat_id,
                 media=media_group,

--- a/src/instagram_video_bot/utils/health_check.py
+++ b/src/instagram_video_bot/utils/health_check.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 
 from ..config.settings import settings
+from ..services.state_store import StateStore
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,23 @@ def check_health() -> bool:
         ):
             logger.error("Instagram credentials are not set")
             return False
+
+        state_db_path = getattr(settings, "STATE_DB_PATH", None)
+        if state_db_path:
+            try:
+                store = StateStore(Path(state_db_path))
+                stale_active_jobs = store.get_stale_active_job_count(
+                    older_than_seconds=getattr(settings, "INSTAGRAM_PROVIDER_TIMEOUT_SECONDS", 180) * 2
+                )
+                if stale_active_jobs:
+                    logger.error("State database has %s stale active jobs", stale_active_jobs)
+                    return False
+                recent_timeouts = store.get_recent_provider_timeout_count(window_seconds=60 * 60)
+                if recent_timeouts:
+                    logger.warning("Recent provider timeouts in the last hour: %s", recent_timeouts)
+            except Exception as error:
+                logger.error("Cannot inspect state database: %s", error)
+                return False
 
         logger.info("Health check passed")
         return True

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+from src.instagram_video_bot.services.state_store import StateStore
 from src.instagram_video_bot.utils import health_check
 
 
@@ -58,3 +59,36 @@ def test_check_health_accepts_multi_account_mode_without_single_account_credenti
     monkeypatch.setattr(health_check, "settings", fake_settings)
 
     assert health_check.check_health() is True
+
+
+def test_check_health_fails_when_state_db_has_stale_active_jobs(monkeypatch, tmp_path):
+    temp_dir = tmp_path / "temp"
+    temp_dir.mkdir()
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    db_path = temp_dir / "state.db"
+    store = StateStore(db_path)
+    store.create_job(
+        "stale-job",
+        77,
+        "https://www.instagram.com/reel/stale/",
+        "instagram",
+        "running",
+    )
+    with store._lock, store._conn:
+        store._conn.execute(
+            "UPDATE jobs SET created_at = '2026-01-01T00:00:00+00:00', started_at = '2026-01-01T00:00:00+00:00' WHERE job_id = 'stale-job'"
+        )
+
+    fake_settings = SimpleNamespace(
+        TEMP_DIR=temp_dir,
+        BASE_DIR=tmp_path,
+        BOT_TOKEN="token",
+        IG_USERNAME="username",
+        IG_PASSWORD="password",
+        STATE_DB_PATH=db_path,
+        INSTAGRAM_PROVIDER_TIMEOUT_SECONDS=180,
+    )
+    monkeypatch.setattr(health_check, "settings", fake_settings)
+
+    assert health_check.check_health() is False

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -22,6 +22,53 @@ async def _wait_for_start_count(started: list[tuple[str, int] | str], count: int
     await asyncio.wait_for(_wait(), timeout=1)
 
 
+def test_job_manager_reconciles_interrupted_persisted_jobs_on_startup(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    store.create_job("running-job", 77, "https://www.instagram.com/reel/running/", "instagram", "running")
+    store.create_request(
+        "running-request",
+        "running-job",
+        77,
+        1001,
+        "alice",
+        "instagram",
+        "https://www.instagram.com/reel/running/",
+        "running",
+    )
+    store.start_job_metrics(
+        job_id="running-job",
+        chat_id=77,
+        provider="instagram",
+        normalized_url="https://www.instagram.com/reel/running/",
+    )
+    store.mark_job_metrics_started("running-job")
+    store.create_job("queued-job", 77, "https://www.instagram.com/reel/queued/", "instagram", "queued")
+
+    JobManager(store)
+
+    with store._lock:
+        jobs = {
+            row["job_id"]: dict(row)
+            for row in store._conn.execute(
+                "SELECT job_id, status, error_class, finished_at FROM jobs ORDER BY job_id"
+            ).fetchall()
+        }
+        request = store._conn.execute(
+            "SELECT status FROM request_events WHERE request_id = 'running-request'"
+        ).fetchone()
+        metrics = store._conn.execute(
+            "SELECT status, failure_class, finished_at FROM performance_metrics WHERE job_id = 'running-job'"
+        ).fetchone()
+
+    assert jobs["running-job"]["status"] == "cancelled"
+    assert jobs["running-job"]["error_class"] == "process_restarted"
+    assert jobs["running-job"]["finished_at"] is not None
+    assert jobs["queued-job"]["status"] == "cancelled"
+    assert request["status"] == "cancelled"
+    assert metrics["status"] == "cancelled"
+    assert metrics["failure_class"] == "process_restarted"
+
+
 @pytest.mark.asyncio
 async def test_promote_delivery_request_wakes_waiters_and_rotates_future(tmp_path):
     store = StateStore(tmp_path / "state.db")

--- a/tests/test_main_environment.py
+++ b/tests/test_main_environment.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from src.instagram_video_bot import __main__ as main_module
@@ -18,6 +20,16 @@ def test_check_environment_allows_missing_instagram_credentials(monkeypatch):
     monkeypatch.setattr(main_module.os.path, "exists", lambda _path: False)
 
     main_module.check_environment()
+
+
+def test_setup_logging_suppresses_noisy_request_loggers(monkeypatch):
+    monkeypatch.setattr(main_module.settings, "LOG_LEVEL", "INFO", raising=False)
+
+    main_module.setup_logging()
+
+    assert logging.getLogger("instagrapi").level == logging.WARNING
+    assert logging.getLogger("private_request").level == logging.WARNING
+    assert logging.getLogger("public_request").level == logging.WARNING
 
 
 def test_main_multi_account_startup_does_not_login_before_bot_run(monkeypatch, tmp_path):

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -218,6 +218,34 @@ async def test_send_carousel_uses_media_group(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_send_large_carousel_respects_telegram_album_limit(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _FakeBot()
+    context = _FakeContext(fake_bot)
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    media_items = []
+    for index in range(11):
+        media_file = tmp_path / f"{index}.jpg"
+        media_file.write_bytes(b"photo")
+        media_items.append(MediaItem(file_path=media_file, media_type="photo"))
+
+    info = VideoInfo(
+        file_path=media_items[0].file_path,
+        title="Large album",
+        media_items=media_items,
+        primary_media_type="photo",
+    )
+
+    await telegram_bot._send_media(context, request_context, info)
+
+    assert len(fake_bot.group_calls) == 1
+    assert len(fake_bot.group_calls[0]["media"]) == 10
+    assert len(fake_bot.photo_calls) == 1
+    assert fake_bot.photo_calls[0]["caption"] is None
+
+
+@pytest.mark.asyncio
 async def test_send_media_group_video_includes_probe_metadata(tmp_path):
     telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
     fake_bot = _FakeBot()
@@ -914,6 +942,29 @@ async def test_admin_status_reports_owner_settings(monkeypatch, tmp_path):
     assert "Статистика: выключена" in reply
     assert "Лимит чата: 5" in reply
     assert "Лимит на пользователя: 2" in reply
+
+
+@pytest.mark.asyncio
+async def test_admin_status_reports_stale_active_jobs(monkeypatch, tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    update = _FakeUpdate("/admin_status")
+    context = _FakeContext(_FakeBot())
+    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.settings.BOT_OWNER_USER_ID", 1001)
+    telegram_bot.state_store.create_job(
+        "stale-job",
+        77,
+        "https://www.instagram.com/reel/stale/",
+        "instagram",
+        "running",
+    )
+    with telegram_bot.state_store._lock, telegram_bot.state_store._conn:
+        telegram_bot.state_store._conn.execute(
+            "UPDATE jobs SET created_at = '2026-01-01T00:00:00+00:00', started_at = '2026-01-01T00:00:00+00:00' WHERE job_id = 'stale-job'"
+        )
+
+    await telegram_bot.admin_status_command(update, context)
+
+    assert "Зависших активных задач: 1" in update.message.replies[-1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- chunk Telegram media albums at the platform limit so large Instagram carousels no longer fail
- reconcile interrupted queued/running jobs on startup and expose stale-job/provider-timeout counters in admin status
- extend health checks to flag stale active jobs and suppress noisy request/proxy logs from third-party clients

## Verification
- uv run pytest -q
- 167 passed in 10.42s

Closes #25