### PR TITLE
Reduce reel delivery latency

### DIFF
--- a/src/instagram_video_bot/config/settings.py
+++ b/src/instagram_video_bot/config/settings.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     IG_FAST_METHOD_ENABLED: bool = True
     IG_FAST_TIMEOUT_CONNECT: int = 10
     IG_FAST_TIMEOUT_READ: int = 45
+    IG_FAST_MIN_DELAY_BETWEEN_DOWNLOADS: float = 0.5
+    IG_FAST_RANDOM_DELAY_MIN_SECONDS: float = 0.0
+    IG_FAST_RANDOM_DELAY_MAX_SECONDS: float = 0.0
+    IG_FAST_MAX_MEDIA_DOWNLOAD_WORKERS: int = 4
     
     # Proxy settings (single proxy for backward compatibility)
     PROXY_HOST: Optional[str] = None
@@ -76,6 +80,9 @@ class Settings(BaseSettings):
     INSTAGRAM_ACCOUNT_LEASE_WAIT_SECONDS: float = 20.0
     RECENT_RESULT_TTL_SECONDS: int = 60 * 60 * 4
     MAX_LINKS_PER_MESSAGE: int = 5
+    TELEGRAM_CONCURRENT_UPDATES: int = 4
+    TELEGRAM_CONNECTION_POOL_SIZE: int = 16
+    TELEGRAM_MEDIA_WRITE_TIMEOUT_SECONDS: float = 60.0
     
     # Docker-specific settings
     RUNNING_IN_DOCKER: bool = os.path.exists('/.dockerenv')

--- a/src/instagram_video_bot/services/download_models.py
+++ b/src/instagram_video_bot/services/download_models.py
@@ -17,6 +17,7 @@ class MediaItem:
     duration: Optional[float] = None
     width: Optional[int] = None
     height: Optional[int] = None
+    telegram_file_id: Optional[str] = None
 
 
 @dataclass

--- a/src/instagram_video_bot/services/instagram_fast_extractor.py
+++ b/src/instagram_video_bot/services/instagram_fast_extractor.py
@@ -9,12 +9,15 @@ import json
 import logging
 import random
 import re
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
 from urllib.parse import quote, urlparse
 
 import requests
+
+from ..config.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -448,50 +451,71 @@ class InstagramFastExtractor:
     ) -> List[DownloadedMedia]:
         """Download extracted media URLs to local files."""
         output_dir.mkdir(parents=True, exist_ok=True)
-        downloaded: List[DownloadedMedia] = []
+        if not media_items:
+            return []
 
-        for index, item in enumerate(media_items, start=1):
-            extension = self._guess_extension(item)
-            out_path = output_dir / f"instagram_{shortcode}_{index}.{extension}"
+        max_workers = max(1, min(settings.IG_FAST_MAX_MEDIA_DOWNLOAD_WORKERS, len(media_items)))
+        if max_workers == 1:
+            return [
+                self._download_one_media_item(shortcode, index, item, output_dir)
+                for index, item in enumerate(media_items, start=1)
+            ]
 
-            response = self._request_raw(
-                method="GET",
-                url=item.url,
-                headers=self._download_headers(),
-                stream=True,
-            )
-            if response is None:
-                raise InstagramFastExtractorError(f"Failed to download media item {index}")
+        results: list[DownloadedMedia | None] = [None] * len(media_items)
+        with ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ig-fast-media") as executor:
+            futures = {
+                executor.submit(self._download_one_media_item, shortcode, index, item, output_dir): index - 1
+                for index, item in enumerate(media_items, start=1)
+            }
+            for future, result_index in futures.items():
+                results[result_index] = future.result()
 
-            content_type = (response.headers.get("content-type") or "").lower()
-            if item.media_type == "video" and content_type and "video" not in content_type:
-                logger.warning("Fast media content-type mismatch for video: %s", content_type)
-            if item.media_type == "photo" and content_type and "image" not in content_type:
-                logger.warning("Fast media content-type mismatch for photo: %s", content_type)
+        return [item for item in results if item is not None]
 
-            total_written = 0
-            with open(out_path, "wb") as file_handle:
-                for chunk in response.iter_content(chunk_size=1024 * 64):
-                    if not chunk:
-                        continue
-                    file_handle.write(chunk)
-                    total_written += len(chunk)
+    def _download_one_media_item(
+        self,
+        shortcode: str,
+        index: int,
+        item: ExtractedMedia,
+        output_dir: Path,
+    ) -> DownloadedMedia:
+        extension = self._guess_extension(item)
+        out_path = output_dir / f"instagram_{shortcode}_{index}.{extension}"
 
-            if total_written <= 0:
-                out_path.unlink(missing_ok=True)
-                raise InstagramFastExtractorError(f"Downloaded empty media item {index}")
+        response = self._request_raw(
+            method="GET",
+            url=item.url,
+            headers=self._download_headers(),
+            stream=True,
+        )
+        if response is None:
+            raise InstagramFastExtractorError(f"Failed to download media item {index}")
 
-            downloaded.append(
-                DownloadedMedia(
-                    file_path=out_path,
-                    media_type=item.media_type,
-                    duration=item.duration,
-                    width=item.width,
-                    height=item.height,
-                )
-            )
+        content_type = (response.headers.get("content-type") or "").lower()
+        if item.media_type == "video" and content_type and "video" not in content_type:
+            logger.warning("Fast media content-type mismatch for video: %s", content_type)
+        if item.media_type == "photo" and content_type and "image" not in content_type:
+            logger.warning("Fast media content-type mismatch for photo: %s", content_type)
 
-        return downloaded
+        total_written = 0
+        with open(out_path, "wb") as file_handle:
+            for chunk in response.iter_content(chunk_size=1024 * 64):
+                if not chunk:
+                    continue
+                file_handle.write(chunk)
+                total_written += len(chunk)
+
+        if total_written <= 0:
+            out_path.unlink(missing_ok=True)
+            raise InstagramFastExtractorError(f"Downloaded empty media item {index}")
+
+        return DownloadedMedia(
+            file_path=out_path,
+            media_type=item.media_type,
+            duration=item.duration,
+            width=item.width,
+            height=item.height,
+        )
 
     def _normalize_url(self, url: str) -> str:
         """Normalize incoming URLs and alias ddinstagram hostnames."""

--- a/src/instagram_video_bot/services/state_store.py
+++ b/src/instagram_video_bot/services/state_store.py
@@ -691,6 +691,39 @@ class StateStore:
                 ),
             )
 
+    def update_cached_telegram_file_ids(
+        self,
+        chat_id: int,
+        normalized_url: str,
+        telegram_file_ids: list[str | None],
+    ) -> None:
+        """Persist Telegram file IDs for cached media so repeats can skip uploads."""
+        with self._lock, self._conn:
+            row = self._conn.execute(
+                """
+                SELECT media_json
+                FROM recent_results
+                WHERE cache_key = ?
+                """,
+                (self._cache_key(chat_id, normalized_url),),
+            ).fetchone()
+            if row is None:
+                return
+
+            media_items = json.loads(row["media_json"])
+            for media_item, file_id in zip(media_items, telegram_file_ids):
+                if file_id:
+                    media_item["telegram_file_id"] = file_id
+
+            self._conn.execute(
+                """
+                UPDATE recent_results
+                SET media_json = ?
+                WHERE cache_key = ?
+                """,
+                (json.dumps(media_items), self._cache_key(chat_id, normalized_url)),
+            )
+
     def purge_expired_results(self) -> list[Path]:
         now = _utc_now().isoformat()
         expired_paths: list[Path] = []

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -675,14 +675,19 @@ class TelegramBot:
         self._validate_media_files([item.file_path for item in media_items])
         caption_text = self._build_caption_text(video_info.title)
 
+        telegram_file_ids: list[str | None] = []
+
         if len(media_items) == 1:
             media_item = media_items[0]
-            await self._send_single_media_item(
-                context,
-                request_context,
-                media_item,
-                caption_text,
+            telegram_file_ids.append(
+                await self._send_single_media_item(
+                    context,
+                    request_context,
+                    media_item,
+                    caption_text,
+                )
             )
+            self._persist_telegram_file_ids(request_context, telegram_file_ids)
             return
 
         caption_available = caption_text
@@ -690,19 +695,24 @@ class TelegramBot:
             chunk = media_items[offset : offset + self.TELEGRAM_MEDIA_GROUP_LIMIT]
             chunk_caption = caption_available if offset == 0 else None
             if len(chunk) == 1:
-                await self._send_single_media_item(
-                    context,
-                    request_context,
-                    chunk[0],
-                    chunk_caption,
+                telegram_file_ids.append(
+                    await self._send_single_media_item(
+                        context,
+                        request_context,
+                        chunk[0],
+                        chunk_caption,
+                    )
                 )
             else:
-                await self._send_media_group_chunk(
-                    context,
-                    request_context,
-                    chunk,
-                    chunk_caption,
+                telegram_file_ids.extend(
+                    await self._send_media_group_chunk(
+                        context,
+                        request_context,
+                        chunk,
+                        chunk_caption,
+                    )
                 )
+        self._persist_telegram_file_ids(request_context, telegram_file_ids)
 
     async def _send_single_media_item(
         self,
@@ -710,10 +720,28 @@ class TelegramBot:
         request_context: RequestContext,
         media_item: MediaItem,
         caption_text: str | None,
-    ) -> None:
+    ) -> str | None:
+        if media_item.telegram_file_id:
+            if media_item.media_type == "video":
+                message = await context.bot.send_video(
+                    chat_id=request_context.chat_id,
+                    video=media_item.telegram_file_id,
+                    caption=caption_text,
+                    reply_to_message_id=request_context.original_message_id,
+                    **self._telegram_video_kwargs(media_item),
+                )
+            else:
+                message = await context.bot.send_photo(
+                    chat_id=request_context.chat_id,
+                    photo=media_item.telegram_file_id,
+                    caption=caption_text,
+                    reply_to_message_id=request_context.original_message_id,
+                )
+            return self._extract_telegram_file_id(message, media_item.media_type)
+
         with open(media_item.file_path, "rb") as media_file:
             if media_item.media_type == "video":
-                await context.bot.send_video(
+                message = await context.bot.send_video(
                     chat_id=request_context.chat_id,
                     video=media_file,
                     caption=caption_text,
@@ -721,12 +749,13 @@ class TelegramBot:
                     **self._telegram_video_kwargs(media_item),
                 )
             else:
-                await context.bot.send_photo(
+                message = await context.bot.send_photo(
                     chat_id=request_context.chat_id,
                     photo=media_file,
                     caption=caption_text,
                     reply_to_message_id=request_context.original_message_id,
                 )
+        return self._extract_telegram_file_id(message, media_item.media_type)
 
     async def _send_media_group_chunk(
         self,
@@ -734,27 +763,56 @@ class TelegramBot:
         request_context: RequestContext,
         media_items: list[MediaItem],
         caption_text: str | None,
-    ) -> None:
+    ) -> list[str | None]:
         with ExitStack() as stack:
             media_group = []
             for index, media_item in enumerate(media_items):
-                media_file = stack.enter_context(open(media_item.file_path, "rb"))
+                media_value = media_item.telegram_file_id
+                if not media_value:
+                    media_value = stack.enter_context(open(media_item.file_path, "rb"))
                 item_caption = caption_text if index == 0 else None
                 if media_item.media_type == "video":
                     media_group.append(
                         InputMediaVideo(
-                            media=media_file,
+                            media=media_value,
                             caption=item_caption,
                             **self._telegram_video_kwargs(media_item),
                         )
                     )
                 else:
-                    media_group.append(InputMediaPhoto(media=media_file, caption=item_caption))
-            await context.bot.send_media_group(
+                    media_group.append(InputMediaPhoto(media=media_value, caption=item_caption))
+            messages = await context.bot.send_media_group(
                 chat_id=request_context.chat_id,
                 media=media_group,
                 reply_to_message_id=request_context.original_message_id,
             )
+        return [
+            self._extract_telegram_file_id(message, media_item.media_type)
+            for message, media_item in zip(messages or [], media_items)
+        ]
+
+    def _persist_telegram_file_ids(
+        self,
+        request_context: RequestContext,
+        telegram_file_ids: list[str | None],
+    ) -> None:
+        if not telegram_file_ids or not any(telegram_file_ids):
+            return
+        self.state_store.update_cached_telegram_file_ids(
+            request_context.chat_id,
+            request_context.normalized_url,
+            telegram_file_ids,
+        )
+
+    @staticmethod
+    def _extract_telegram_file_id(message: Any, media_type: str) -> str | None:
+        if media_type == "video":
+            video = getattr(message, "video", None)
+            return getattr(video, "file_id", None)
+        photos = getattr(message, "photo", None)
+        if photos:
+            return getattr(photos[-1], "file_id", None)
+        return None
 
     @staticmethod
     def _cleanup_files(files: List[Path]) -> None:
@@ -785,6 +843,7 @@ class TelegramBot:
                 duration=item.get("duration"),
                 width=item.get("width"),
                 height=item.get("height"),
+                telegram_file_id=item.get("telegram_file_id"),
             )
             for item in cached.media_items
         ]
@@ -1021,6 +1080,9 @@ class TelegramBot:
         self.application = (
             ApplicationBuilder()
             .token(settings.BOT_TOKEN)
+            .concurrent_updates(settings.TELEGRAM_CONCURRENT_UPDATES)
+            .connection_pool_size(settings.TELEGRAM_CONNECTION_POOL_SIZE)
+            .media_write_timeout(settings.TELEGRAM_MEDIA_WRITE_TIMEOUT_SECONDS)
             .build()
         )
 

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -12,7 +12,7 @@ import time
 from typing import Any, List, Optional
 
 from telegram import InputMediaPhoto, InputMediaVideo, Message, Update
-from telegram.error import NetworkError, TelegramError
+from telegram.error import BadRequest, NetworkError, TelegramError
 from telegram.ext import (
     Application,
     ApplicationBuilder,
@@ -722,40 +722,59 @@ class TelegramBot:
         caption_text: str | None,
     ) -> str | None:
         if media_item.telegram_file_id:
-            if media_item.media_type == "video":
-                message = await context.bot.send_video(
-                    chat_id=request_context.chat_id,
-                    video=media_item.telegram_file_id,
-                    caption=caption_text,
-                    reply_to_message_id=request_context.original_message_id,
-                    **self._telegram_video_kwargs(media_item),
+            try:
+                message = await self._send_single_media_value(
+                    context,
+                    request_context,
+                    media_item,
+                    caption_text,
+                    media_item.telegram_file_id,
                 )
-            else:
-                message = await context.bot.send_photo(
-                    chat_id=request_context.chat_id,
-                    photo=media_item.telegram_file_id,
-                    caption=caption_text,
-                    reply_to_message_id=request_context.original_message_id,
+                return self._extract_telegram_file_id(message, media_item.media_type)
+            except BadRequest as exc:
+                if not self._is_rejected_telegram_file_id(exc):
+                    raise
+                logger.info(
+                    "Cached Telegram file_id rejected; retrying local media upload",
+                    extra={
+                        "chat_id": request_context.chat_id,
+                        "media_type": media_item.media_type,
+                        "failure_class": "telegram_file_id_rejected",
+                    },
                 )
-            return self._extract_telegram_file_id(message, media_item.media_type)
 
         with open(media_item.file_path, "rb") as media_file:
-            if media_item.media_type == "video":
-                message = await context.bot.send_video(
-                    chat_id=request_context.chat_id,
-                    video=media_file,
-                    caption=caption_text,
-                    reply_to_message_id=request_context.original_message_id,
-                    **self._telegram_video_kwargs(media_item),
-                )
-            else:
-                message = await context.bot.send_photo(
-                    chat_id=request_context.chat_id,
-                    photo=media_file,
-                    caption=caption_text,
-                    reply_to_message_id=request_context.original_message_id,
-                )
+            message = await self._send_single_media_value(
+                context,
+                request_context,
+                media_item,
+                caption_text,
+                media_file,
+            )
         return self._extract_telegram_file_id(message, media_item.media_type)
+
+    async def _send_single_media_value(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        request_context: RequestContext,
+        media_item: MediaItem,
+        caption_text: str | None,
+        media_value: Any,
+    ) -> Message:
+        if media_item.media_type == "video":
+            return await context.bot.send_video(
+                chat_id=request_context.chat_id,
+                video=media_value,
+                caption=caption_text,
+                reply_to_message_id=request_context.original_message_id,
+                **self._telegram_video_kwargs(media_item),
+            )
+        return await context.bot.send_photo(
+            chat_id=request_context.chat_id,
+            photo=media_value,
+            caption=caption_text,
+            reply_to_message_id=request_context.original_message_id,
+        )
 
     async def _send_media_group_chunk(
         self,
@@ -764,10 +783,49 @@ class TelegramBot:
         media_items: list[MediaItem],
         caption_text: str | None,
     ) -> list[str | None]:
+        try:
+            messages = await self._send_media_group_values(
+                context,
+                request_context,
+                media_items,
+                caption_text,
+            )
+        except BadRequest as exc:
+            if not any(item.telegram_file_id for item in media_items) or not self._is_rejected_telegram_file_id(exc):
+                raise
+            logger.info(
+                "Cached Telegram file_id rejected in media group; retrying local media upload",
+                extra={
+                    "chat_id": request_context.chat_id,
+                    "media_count": len(media_items),
+                    "failure_class": "telegram_file_id_rejected",
+                },
+            )
+            messages = await self._send_media_group_values(
+                context,
+                request_context,
+                media_items,
+                caption_text,
+                force_local_upload=True,
+            )
+        return [
+            self._extract_telegram_file_id(message, media_item.media_type)
+            for message, media_item in zip(messages or [], media_items)
+        ]
+
+    async def _send_media_group_values(
+        self,
+        context: ContextTypes.DEFAULT_TYPE,
+        request_context: RequestContext,
+        media_items: list[MediaItem],
+        caption_text: str | None,
+        *,
+        force_local_upload: bool = False,
+    ) -> list[Message]:
         with ExitStack() as stack:
             media_group = []
             for index, media_item in enumerate(media_items):
-                media_value = media_item.telegram_file_id
+                media_value = None if force_local_upload else media_item.telegram_file_id
                 if not media_value:
                     media_value = stack.enter_context(open(media_item.file_path, "rb"))
                 item_caption = caption_text if index == 0 else None
@@ -781,15 +839,23 @@ class TelegramBot:
                     )
                 else:
                     media_group.append(InputMediaPhoto(media=media_value, caption=item_caption))
-            messages = await context.bot.send_media_group(
+            return await context.bot.send_media_group(
                 chat_id=request_context.chat_id,
                 media=media_group,
                 reply_to_message_id=request_context.original_message_id,
             )
-        return [
-            self._extract_telegram_file_id(message, media_item.media_type)
-            for message, media_item in zip(messages or [], media_items)
-        ]
+
+    @staticmethod
+    def _is_rejected_telegram_file_id(error: TelegramError) -> bool:
+        message = str(error).lower()
+        return any(
+            marker in message
+            for marker in (
+                "wrong file identifier",
+                "file_id_invalid",
+                "file reference expired",
+            )
+        )
 
     def _persist_telegram_file_ids(
         self,

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -56,6 +56,13 @@ class VideoDownloader:
         """Initialize the video downloader."""
         self.min_delay_between_downloads = 10
         self.random_delay_range = (1.0, 3.0)
+        self.fast_min_delay_between_downloads = max(
+            0.0, float(settings.IG_FAST_MIN_DELAY_BETWEEN_DOWNLOADS)
+        )
+        self.fast_random_delay_range = (
+            max(0.0, float(settings.IG_FAST_RANDOM_DELAY_MIN_SECONDS)),
+            max(0.0, float(settings.IG_FAST_RANDOM_DELAY_MAX_SECONDS)),
+        )
         fast_extractor = InstagramFastExtractor(
             timeout_connect=settings.IG_FAST_TIMEOUT_CONNECT,
             timeout_read=settings.IG_FAST_TIMEOUT_READ,
@@ -179,7 +186,11 @@ class VideoDownloader:
             fast_started_at = perf_counter()
             try:
                 async with self._instagram_provider_slot():
-                    await self._apply_instagram_throttle(lease_key)
+                    await self._apply_instagram_throttle(
+                        lease_key,
+                        min_delay=self.fast_min_delay_between_downloads,
+                        random_delay_range=self.fast_random_delay_range,
+                    )
                     fast_result = await self._run_instagram_sync(
                         lambda: self.instagram_adapter.download_with_fast_method(url, output_dir)
                     )
@@ -434,23 +445,31 @@ class VideoDownloader:
             "www.x.com",
         }
 
-    async def _apply_instagram_throttle(self, key: str) -> None:
-        """Apply a conservative per-key delay before Instagram work."""
+    async def _apply_instagram_throttle(
+        self,
+        key: str,
+        *,
+        min_delay: float | None = None,
+        random_delay_range: tuple[float, float] | None = None,
+    ) -> None:
+        """Apply a per-key delay before Instagram work."""
+        effective_min_delay = self.min_delay_between_downloads if min_delay is None else max(0.0, min_delay)
+        effective_jitter = self.random_delay_range if random_delay_range is None else random_delay_range
         sleep_for = 0.0
         with self._throttle_lock:
             last_download = self._last_instagram_download_by_key.get(key, 0.0)
             current_time = time.time()
             time_since_last = current_time - last_download
-            if time_since_last < self.min_delay_between_downloads:
-                sleep_for = self.min_delay_between_downloads - time_since_last
+            if time_since_last < effective_min_delay:
+                sleep_for = effective_min_delay - time_since_last
             self._last_instagram_download_by_key[key] = current_time + sleep_for
 
         if sleep_for > 0:
             logger.info("Instagram throttle delay %.1fs for key %s", sleep_for, key)
             await asyncio.sleep(sleep_for)
 
-        if self.random_delay_range[1] > 0:
-            jitter = random.uniform(*self.random_delay_range)
+        if effective_jitter[1] > 0:
+            jitter = random.uniform(*effective_jitter)
             logger.debug("Adding Instagram jitter delay: %.1fs", jitter)
             await asyncio.sleep(jitter)
 

--- a/tests/test_instagram_fast_extractor.py
+++ b/tests/test_instagram_fast_extractor.py
@@ -1,3 +1,6 @@
+import threading
+import time
+
 import pytest
 
 from src.instagram_video_bot.services.instagram_fast_extractor import (
@@ -92,6 +95,46 @@ def test_parse_carousel_mobile_item_preserves_order():
     assert [item.media_type for item in media_items] == ["photo", "video"]
     assert media_items[0].url.endswith("1.jpg")
     assert media_items[1].url.endswith("2-high.mp4")
+
+
+def test_download_media_items_runs_carousel_downloads_concurrently(monkeypatch, tmp_path):
+    extractor = InstagramFastExtractor()
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+
+    class _StreamResponse:
+        headers = {"content-type": "video/mp4"}
+
+        def iter_content(self, chunk_size):
+            yield b"video"
+
+    def fake_request_raw(**kwargs):
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+        return _StreamResponse()
+
+    monkeypatch.setattr(extractor, "_request_raw", fake_request_raw)
+    media_items = [
+        type("Item", (), {"url": f"https://cdn.example.com/{index}.mp4", "media_type": "video", "duration": None, "width": None, "height": None})()
+        for index in range(4)
+    ]
+
+    downloaded = extractor._download_media_items("abc123", media_items, tmp_path)
+
+    assert len(downloaded) == 4
+    assert [item.file_path.name for item in downloaded] == [
+        "instagram_abc123_1.mp4",
+        "instagram_abc123_2.mp4",
+        "instagram_abc123_3.mp4",
+        "instagram_abc123_4.mp4",
+    ]
+    assert max_active > 1
 
 
 def test_share_url_resolution_to_canonical_post(monkeypatch):

--- a/tests/test_telegram_bot_errors.py
+++ b/tests/test_telegram_bot_errors.py
@@ -32,6 +32,15 @@ def test_run_registers_global_error_handler(monkeypatch):
         def token(self, _token):
             return self
 
+        def concurrent_updates(self, _updates):
+            return self
+
+        def connection_pool_size(self, _size):
+            return self
+
+        def media_write_timeout(self, _timeout):
+            return self
+
         def build(self):
             return FakeApplication()
 

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -26,12 +26,22 @@ class _FakeBot:
 
     async def send_video(self, **kwargs):
         self.video_calls.append(kwargs)
+        return SimpleNamespace(video=SimpleNamespace(file_id="tg-video-file-id"), photo=None)
 
     async def send_photo(self, **kwargs):
         self.photo_calls.append(kwargs)
+        return SimpleNamespace(video=None, photo=[SimpleNamespace(file_id="tg-photo-file-id")])
 
     async def send_media_group(self, **kwargs):
         self.group_calls.append(kwargs)
+        messages = []
+        for item in kwargs["media"]:
+            media_type = getattr(item, "type", "")
+            if media_type == "video":
+                messages.append(SimpleNamespace(video=SimpleNamespace(file_id="tg-group-video-id"), photo=None))
+            else:
+                messages.append(SimpleNamespace(video=None, photo=[SimpleNamespace(file_id="tg-group-photo-id")]))
+        return messages
 
     async def get_chat_member(self, chat_id: int, user_id: int):
         return SimpleNamespace(status=self.member_status)
@@ -995,6 +1005,53 @@ async def test_cache_hit_records_performance_metrics(monkeypatch, tmp_path):
     summary = telegram_bot.state_store.get_performance_summary(77, limit=50)
     assert summary["cache_hits"] == 1
     assert summary["avg_delivery_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_send_media_persists_and_reuses_telegram_file_id(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    telegram_bot = TelegramBot(state_store=store)
+    context = _FakeContext(_FakeBot())
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    media_file = tmp_path / "cached-file-id.mp4"
+    media_file.write_bytes(b"video")
+    store.save_cached_result(
+        chat_id=request_context.chat_id,
+        normalized_url=request_context.normalized_url,
+        provider="instagram",
+        title="cached file id",
+        media_items=[
+            {
+                "file_path": str(media_file),
+                "media_type": "video",
+                "caption": None,
+                "duration": None,
+                "width": None,
+                "height": None,
+            }
+        ],
+        ttl_seconds=3600,
+    )
+
+    info = VideoInfo(
+        file_path=media_file,
+        title="cached file id",
+        media_items=[MediaItem(file_path=media_file, media_type="video")],
+        primary_media_type="video",
+    )
+
+    await telegram_bot._send_media(context, request_context, info)
+
+    cached = store.get_cached_result(request_context.chat_id, request_context.normalized_url)
+    assert cached is not None
+    assert cached.media_items[0]["telegram_file_id"] == "tg-video-file-id"
+
+    cached_info = telegram_bot._video_info_from_cache(cached)
+    second_fake_bot = _FakeBot()
+    await telegram_bot._send_media(_FakeContext(second_fake_bot), request_context, cached_info)
+
+    assert second_fake_bot.video_calls[0]["video"] == "tg-video-file-id"
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_bot_media_send.py
+++ b/tests/test_telegram_bot_media_send.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from telegram.error import BadRequest
 
 from src.instagram_video_bot.services.state_store import StateStore
 from src.instagram_video_bot.services.download_models import ProviderExecutionMetrics
@@ -45,6 +46,22 @@ class _FakeBot:
 
     async def get_chat_member(self, chat_id: int, user_id: int):
         return SimpleNamespace(status=self.member_status)
+
+
+class _RejectStaleFileIdBot(_FakeBot):
+    async def send_video(self, **kwargs):
+        self.video_calls.append(kwargs)
+        if kwargs["video"] == "stale-video-file-id":
+            raise BadRequest("Wrong file identifier/HTTP URL specified")
+        return SimpleNamespace(video=SimpleNamespace(file_id="fresh-video-file-id"), photo=None)
+
+
+class _RejectStaleGroupFileIdBot(_FakeBot):
+    async def send_media_group(self, **kwargs):
+        self.group_calls.append(kwargs)
+        if any(getattr(item, "media", None) == "stale-photo-file-id" for item in kwargs["media"]):
+            raise BadRequest("Wrong file identifier/HTTP URL specified")
+        return [SimpleNamespace(video=None, photo=[SimpleNamespace(file_id="fresh-group-photo-id")]) for _ in kwargs["media"]]
 
 
 class _FakeStatusMessage:
@@ -1052,6 +1069,82 @@ async def test_send_media_persists_and_reuses_telegram_file_id(tmp_path):
     await telegram_bot._send_media(_FakeContext(second_fake_bot), request_context, cached_info)
 
     assert second_fake_bot.video_calls[0]["video"] == "tg-video-file-id"
+
+
+@pytest.mark.asyncio
+async def test_send_media_falls_back_to_local_upload_when_cached_file_id_is_rejected(tmp_path):
+    store = StateStore(tmp_path / "state.db")
+    telegram_bot = TelegramBot(state_store=store)
+    fake_bot = _RejectStaleFileIdBot()
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    media_file = tmp_path / "stale-file-id.mp4"
+    media_file.write_bytes(b"video")
+    store.save_cached_result(
+        chat_id=request_context.chat_id,
+        normalized_url=request_context.normalized_url,
+        provider="instagram",
+        title="cached file id",
+        media_items=[
+            {
+                "file_path": str(media_file),
+                "media_type": "video",
+                "caption": None,
+                "duration": None,
+                "width": None,
+                "height": None,
+                "telegram_file_id": "stale-video-file-id",
+            }
+        ],
+        ttl_seconds=3600,
+    )
+
+    cached = store.get_cached_result(request_context.chat_id, request_context.normalized_url)
+    assert cached is not None
+
+    await telegram_bot._send_media(
+        _FakeContext(fake_bot),
+        request_context,
+        telegram_bot._video_info_from_cache(cached),
+    )
+
+    assert len(fake_bot.video_calls) == 2
+    assert fake_bot.video_calls[0]["video"] == "stale-video-file-id"
+    assert not isinstance(fake_bot.video_calls[1]["video"], str)
+
+    refreshed = store.get_cached_result(request_context.chat_id, request_context.normalized_url)
+    assert refreshed is not None
+    assert refreshed.media_items[0]["telegram_file_id"] == "fresh-video-file-id"
+
+
+@pytest.mark.asyncio
+async def test_send_media_group_falls_back_to_local_upload_when_cached_file_id_is_rejected(tmp_path):
+    telegram_bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    fake_bot = _RejectStaleGroupFileIdBot()
+    request_context = _make_request_context(_FakeStatusMessage())
+
+    first = tmp_path / "stale-1.jpg"
+    second = tmp_path / "stale-2.jpg"
+    first.write_bytes(b"photo")
+    second.write_bytes(b"photo")
+    info = VideoInfo(
+        file_path=first,
+        title="cached album",
+        media_items=[
+            MediaItem(file_path=first, media_type="photo", telegram_file_id="stale-photo-file-id"),
+            MediaItem(file_path=second, media_type="photo", telegram_file_id="fresh-photo-file-id"),
+        ],
+        primary_media_type="photo",
+    )
+
+    await telegram_bot._send_media(_FakeContext(fake_bot), request_context, info)
+
+    assert len(fake_bot.group_calls) == 2
+    assert [item.media for item in fake_bot.group_calls[0]["media"]] == [
+        "stale-photo-file-id",
+        "fresh-photo-file-id",
+    ]
+    assert all(not isinstance(item.media, str) for item in fake_bot.group_calls[1]["media"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -1233,6 +1233,14 @@ async def test_youtube_shorts_url_routes_to_youtube_downloader(tmp_path):
     assert info.primary_media_type == "video"
 
 
+def test_instagram_fast_path_uses_lower_default_throttle():
+    downloader = VideoDownloader()
+
+    assert downloader.fast_min_delay_between_downloads <= 1.0
+    assert downloader.fast_random_delay_range == (0.0, 0.0)
+    assert downloader.min_delay_between_downloads >= 10
+
+
 @pytest.mark.asyncio
 async def test_instagram_fast_success_records_provider_metrics(monkeypatch, tmp_path):
     downloader = VideoDownloader()


### PR DESCRIPTION
## Summary
- reduce default Instagram fast-path throttling while keeping fallback account throttling conservative
- parallelize fast extractor media downloads for carousel/multi-item posts
- cache Telegram file_id values after first upload and reuse them for repeated cached media
- tune Telegram client transport for concurrent updates and larger media writes

## Verification
- uv run pytest -q
- 170 passed in 11.54s
- git diff --check

Closes #27