### PR TITLE
[codex] Quarantine hard Instagram account failures

### DIFF
--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -306,7 +306,8 @@ class VideoDownloader:
                         "error": str(auth_error),
                     },
                 )
-                event = manager.record_account_failure(account, "auth_challenge")
+                account_failure_reason = self._classify_instagram_account_failure(auth_error)
+                event = manager.record_account_failure(account, account_failure_reason)
                 if getattr(event, "should_alert_owner", False) or self.last_account_health_event is None:
                     self.last_account_health_event = event
             except Exception as error:
@@ -423,6 +424,20 @@ class VideoDownloader:
             token in text
             for token in ("timeout", "timed out", "temporary", "temporarily", "connection", "network")
         )
+
+    @staticmethod
+    def _classify_instagram_account_failure(error: Exception) -> str:
+        """Map auth-like Instagram errors to account quarantine reasons."""
+        text = str(error).lower()
+        if "manual verification" in text or "ufac" in text or "web bloks" in text:
+            return "manual_verification"
+        if "unknown step_name" in text or "challenge resolver" in text:
+            return "unresolved_challenge"
+        if "invalid username or password" in text:
+            return "invalid_credentials"
+        if "please wait" in text or ("rate" in text and "limit" in text):
+            return "rate_limited"
+        return "auth_challenge"
 
     @staticmethod
     def _classify_download_error(error: Exception) -> str:

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -364,9 +364,10 @@ class AccountManager:
             account.last_failure_reason = reason
             account.last_failure_at = now
 
-            threshold_reached = (
-                hard_failure and not account.is_banned
-            ) or previous_failures < threshold <= account.consecutive_failures
+            threshold_reached = not account.is_banned and (
+                hard_failure
+                or previous_failures < threshold <= account.consecutive_failures
+            )
             if threshold_reached:
                 account.is_banned = True
                 account.ban_reason = (

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -364,7 +364,9 @@ class AccountManager:
             account.last_failure_reason = reason
             account.last_failure_at = now
 
-            threshold_reached = previous_failures < threshold <= account.consecutive_failures
+            threshold_reached = (
+                hard_failure and not account.is_banned
+            ) or previous_failures < threshold <= account.consecutive_failures
             if threshold_reached:
                 account.is_banned = True
                 account.ban_reason = (

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -324,10 +324,39 @@ class AccountManager:
             account.last_failure_at = None
             self._save_state()
 
+    @staticmethod
+    def _is_hard_account_failure_reason(reason: str) -> bool:
+        """Return true when an account should be quarantined after one failure."""
+        text = reason.lower()
+        hard_tokens = (
+            "auth_challenge",
+            "challenge_required",
+            "manual_verification",
+            "manual verification",
+            "checkpoint",
+            "ufac",
+            "web bloks",
+            "unresolved_challenge",
+            "challenge resolver",
+            "unknown step_name",
+            "invalid_credentials",
+            "invalid username or password",
+            "login_required",
+            "login required",
+            "unauthorized",
+            "401",
+            "rate_limited",
+            "rate limit",
+            "please wait",
+        )
+        return any(token in text for token in hard_tokens)
+
     def record_account_failure(self, account: Account, reason: str) -> AccountHealthEvent:
         """Persist a sequential failure and quarantine accounts at threshold."""
         with self._lock:
-            threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
+            configured_threshold = max(1, settings.ACCOUNT_FAILURE_THRESHOLD)
+            hard_failure = self._is_hard_account_failure_reason(reason)
+            threshold = 1 if hard_failure else configured_threshold
             now = datetime.now()
             previous_failures = account.consecutive_failures
 
@@ -338,7 +367,9 @@ class AccountManager:
             threshold_reached = previous_failures < threshold <= account.consecutive_failures
             if threshold_reached:
                 account.is_banned = True
-                account.ban_reason = f"sequential_failures:{reason}"
+                account.ban_reason = (
+                    f"hard_failure:{reason}" if hard_failure else f"sequential_failures:{reason}"
+                )
                 account.banned_at = now
                 self._leased_accounts.discard(account.username)
 

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -122,6 +122,27 @@ def test_hard_account_failure_quarantines_after_prior_soft_failure(monkeypatch, 
     assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
 
 
+def test_failure_after_hard_quarantine_preserves_original_ban(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+
+    hard_event = manager.record_account_failure(account, "manual_verification")
+    repeated_event = manager.record_account_failure(account, "timeout")
+
+    assert hard_event.threshold_reached is True
+    assert repeated_event.consecutive_failures == 2
+    assert repeated_event.threshold_reached is False
+    assert account.is_banned is True
+    assert account.ban_reason == "hard_failure:manual_verification"
+    assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+
 def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -97,6 +97,31 @@ def test_hard_account_failure_quarantines_immediately(monkeypatch, tmp_path: Pat
     assert saved_account["ban_reason"] == "hard_failure:manual_verification"
 
 
+def test_hard_account_failure_quarantines_after_prior_soft_failure(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 3)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+
+    soft_event = manager.record_account_failure(account, "timeout")
+
+    assert soft_event.threshold_reached is False
+    assert account.is_banned is False
+
+    hard_event = manager.record_account_failure(account, "manual_verification")
+
+    assert hard_event.consecutive_failures == 2
+    assert hard_event.threshold == 1
+    assert hard_event.threshold_reached is True
+    assert account.is_banned is True
+    assert account.ban_reason == "hard_failure:manual_verification"
+    assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+
 def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -72,6 +72,31 @@ def test_account_failure_counter_quarantines_after_threshold(monkeypatch, tmp_pa
     assert saved_account["last_failure_at"]
 
 
+def test_hard_account_failure_quarantines_immediately(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 3)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+
+    event = manager.record_account_failure(account, "manual_verification")
+
+    assert event.consecutive_failures == 1
+    assert event.threshold == 1
+    assert event.threshold_reached is True
+    assert account.is_banned is True
+    assert account.ban_reason == "hard_failure:manual_verification"
+    assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+    state = json.loads(state_file.read_text())
+    saved_account = next(acc for acc in state["accounts"] if acc["username"] == "first")
+    assert saved_account["is_banned"] is True
+    assert saved_account["ban_reason"] == "hard_failure:manual_verification"
+
+
 def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)

--- a/tests/test_video_downloader_flow.py
+++ b/tests/test_video_downloader_flow.py
@@ -65,6 +65,27 @@ class _AuthFailClient:
         return None
 
 
+class _ManualVerificationClient:
+    username = "acc_checkpoint"
+    proxy = None
+
+    def login(self):
+        return True
+
+    def download_video(self, _url: str, _output_dir: Path):
+        raise InstagramAuthError(
+            "Manual verification required via Instagram UFAC web bloks checkpoint"
+        )
+
+    def download_media(self, _url: str, _output_dir: Path):
+        raise InstagramAuthError(
+            "Manual verification required via Instagram UFAC web bloks checkpoint"
+        )
+
+    def get_media_info(self, _url: str):
+        return None
+
+
 class _DownloadErrorClient:
     username = "acc_error"
     proxy = None
@@ -1682,6 +1703,37 @@ async def test_leased_auth_challenge_failure_class_rotates_account(monkeypatch, 
     assert downloader.last_provider_metrics.instagram_auth_failures == 1
     assert downloader.last_provider_metrics.failure_class == "auth_challenge"
     assert manager.failures == [("acc_challenge", "auth_challenge")]
+    assert manager.successes == ["acc_ok"]
+
+
+@pytest.mark.asyncio
+async def test_leased_manual_verification_records_hard_account_reason(monkeypatch, tmp_path):
+    downloader = VideoDownloader()
+    downloader.min_delay_between_downloads = 0
+    downloader.random_delay_range = (0, 0)
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.settings.IG_FAST_METHOD_ENABLED", False)
+
+    expected_path = tmp_path / "after-manual-verification.mp4"
+    expected_path.write_bytes(b"video")
+
+    manager = _LeaseManager([_Account("acc_checkpoint"), _Account("acc_ok")])
+    monkeypatch.setattr("src.instagram_video_bot.services.video_downloader.get_account_manager", lambda: manager)
+
+    clients = {
+        "acc_checkpoint": _ManualVerificationClient(),
+        "acc_ok": _SuccessDownloadClient(expected_path, {"title": "ok", "duration": 10}),
+    }
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.video_downloader.InstagramClient",
+        lambda **kwargs: clients[kwargs["username"]],
+    )
+
+    info = await downloader.download_video("https://www.instagram.com/reel/a/", tmp_path)
+
+    assert info.file_path == expected_path
+    assert downloader.last_provider_metrics.instagram_auth_failures == 1
+    assert downloader.last_provider_metrics.failure_class == "auth_challenge"
+    assert manager.failures == [("acc_checkpoint", "manual_verification")]
     assert manager.successes == ["acc_ok"]
 
 


### PR DESCRIPTION
## Summary
- quarantine hard Instagram account failures after the first occurrence
- preserve broad provider metrics as auth_challenge while recording specific account-health reasons
- add regression coverage for immediate account quarantine and manual-verification reason mapping

## Why
Recent reel attempts spent 60-120 seconds cycling through accounts already hitting UFAC/manual verification, invalid credentials, unresolved challenges, or rate limits. These are hard account-health signals and should not wait for the generic sequential-failure threshold.

## Validation
- uv run pytest -q tests/test_account_manager.py::test_hard_account_failure_quarantines_immediately tests/test_video_downloader_flow.py::test_leased_manual_verification_records_hard_account_reason
- uv run pytest -q tests/test_account_manager.py tests/test_video_downloader_flow.py
- uv run pytest -q
- git diff --check

## Deployment note
Already deployed locally on this machine from commit fc193ec; container image sha256:eac896300a1b1c2a36e35359d86ec2660a1fe5fdfbe92ea53460be84cd162b34 passed health check.