### PR TITLE
[codex] Use Docker Compose v2 commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,43 +34,43 @@ help: ## Show this help message
 	@echo 'Proxy format: user:pass@host:port (http:// added automatically)'
 
 build: ## Build the Docker image
-	docker-compose build
+	docker compose build
 
 up: ## Start the bot in detached mode
-	docker-compose up -d
+	docker compose up -d
 
 down: ## Stop the bot
-	docker-compose down
+	docker compose down
 
 restart: ## Restart the bot
-	docker-compose restart
+	docker compose restart
 
 logs: ## View bot logs (follow mode)
-	docker-compose logs -f
+	docker compose logs -f
 
 shell: ## Open a shell in the running container
-	docker-compose exec instagram-video-bot /bin/bash
+	docker compose exec instagram-video-bot /bin/bash
 
 clean: ## Clean up temporary files and Docker volumes
-	docker-compose down -v
+	docker compose down -v
 	rm -rf temp/* logs/* sessions/* 2fa_qr.png
 
 setup-2fa: ## Set up two-factor authentication
 	./docker-setup-2fa.sh
 
 dev: ## Start in development mode with live reload
-	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 
 dev-build: ## Build for development
-	docker-compose -f docker-compose.yml -f docker-compose.dev.yml build
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml build
 
 test-health: ## Test the health check
-	docker-compose exec instagram-video-bot uv run --no-sync python -m src.instagram_video_bot.utils.health_check
+	docker compose exec instagram-video-bot uv run --no-sync python -m src.instagram_video_bot.utils.health_check
 
 test-proxies: ## Test proxy parsing and configuration
 	@echo "🌐 Testing Proxy Configuration"
 	@echo "Format: user:pass@host:port (http:// added automatically)"
-	@docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python -c "from src.instagram_video_bot.config.settings import settings; proxies = settings.get_proxy_list(); print(f'✅ Found {len(proxies)} proxies:'); [print(f'  {i+1}: {proxy}') for i, proxy in enumerate(proxies[:10])] if proxies else print('❌ No proxies configured in PROXIES environment variable')"
+	@docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python -c "from src.instagram_video_bot.config.settings import settings; proxies = settings.get_proxy_list(); print(f'✅ Found {len(proxies)} proxies:'); [print(f'  {i+1}: {proxy}') for i, proxy in enumerate(proxies[:10])] if proxies else print('❌ No proxies configured in PROXIES environment variable')"
 
 # Account Management Commands
 accounts-list: ## List all accounts from accounts.txt with proxy assignments
@@ -88,26 +88,26 @@ accounts-list: ## List all accounts from accounts.txt with proxy assignments
 	fi
 
 accounts-status: ## Show status of all Instagram accounts
-	docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py status
+	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py status
 
 accounts-setup: ## Setup all accounts (login and create sessions)
-	docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py setup
+	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py setup
 
 accounts-rotate: ## Manually rotate to next available account
-	docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py rotate
+	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py rotate
 
 accounts-reset: ## Reset banned status for all accounts
-	docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py reset
+	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py reset
 
 accounts-reset-old: ## Reset accounts banned longer than HOURS hours (default 24)
-	docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py reset-old --hours $(if $(HOURS),$(HOURS),24)
+	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py reset-old --hours $(if $(HOURS),$(HOURS),24)
 
 # Session Management Commands
 sessions-clean: ## Clean all session files (forces fresh login for all accounts)
-	docker-compose run --rm --entrypoint sh instagram-video-bot -c "rm -f /app/sessions/*.json && echo 'All session files deleted. Accounts will need to login again.'"
+	docker compose run --rm --entrypoint sh instagram-video-bot -c "rm -f /app/sessions/*.json && echo 'All session files deleted. Accounts will need to login again.'"
 
 sessions-backup: ## Backup all session files
-	docker-compose run --rm --entrypoint sh instagram-video-bot -c "mkdir -p /app/sessions/backup && cp /app/sessions/*.json /app/sessions/backup/ 2>/dev/null && echo 'Session files backed up to sessions/backup/' || echo 'No session files to backup'"
+	docker compose run --rm --entrypoint sh instagram-video-bot -c "mkdir -p /app/sessions/backup && cp /app/sessions/*.json /app/sessions/backup/ 2>/dev/null && echo 'Session files backed up to sessions/backup/' || echo 'No session files to backup'"
 
 sessions-restore: ## Restore session files from backup
-	docker-compose run --rm --entrypoint sh instagram-video-bot -c "cp /app/sessions/backup/*.json /app/sessions/ 2>/dev/null && echo 'Session files restored from backup' || echo 'No backup files found'"
+	docker compose run --rm --entrypoint sh instagram-video-bot -c "cp /app/sessions/backup/*.json /app/sessions/ 2>/dev/null && echo 'Session files restored from backup' || echo 'No backup files found'"

--- a/docs/guides/MULTI_ACCOUNT_GUIDE.md
+++ b/docs/guides/MULTI_ACCOUNT_GUIDE.md
@@ -165,7 +165,7 @@ If many accounts get banned:
 
 ```bash
 # 1. Stop the bot
-docker-compose down
+docker compose down
 
 # 2. Wait 24 hours
 
@@ -185,7 +185,7 @@ python3 manage_accounts.py warmup
 
 ```bash
 # Bot logs
-docker-compose logs -f
+docker compose logs -f
 
 # Account state
 cat accounts_state.json | jq
@@ -237,10 +237,10 @@ ACCOUNTS_FILE=vip_accounts.txt python3 manage_accounts.py setup
 With 20 accounts, you can potentially run multiple bot instances:
 ```bash
 # Instance 1 (accounts 1-10)
-BOT_INSTANCE=1 docker-compose up -d
+BOT_INSTANCE=1 docker compose up -d
 
 # Instance 2 (accounts 11-20)  
-BOT_INSTANCE=2 docker-compose -p bot2 up -d
+BOT_INSTANCE=2 docker compose -p bot2 up -d
 ```
 
 **Warning**: This increases detection risk. Use carefully.

--- a/docs/guides/README-Docker.md
+++ b/docs/guides/README-Docker.md
@@ -82,13 +82,13 @@ make up
 
 ### Run commands inside container:
 ```bash
-docker-compose exec instagram-video-bot /bin/bash
+docker compose exec instagram-video-bot /bin/bash
 ```
 
 ### Run Python commands inside the container:
 ```bash
-docker-compose exec instagram-video-bot uv run --no-sync python -m src.instagram_video_bot.utils.health_check
-docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py status
+docker compose exec instagram-video-bot uv run --no-sync python -m src.instagram_video_bot.utils.health_check
+docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py status
 ```
 
 ## Volume Mounts
@@ -104,14 +104,14 @@ The Docker setup uses several volume mounts:
 ### Bot not starting
 Check the logs:
 ```bash
-docker-compose logs instagram-video-bot
+docker compose logs instagram-video-bot
 ```
 
 ### Instagram authentication issues
 1. Verify your `.env` credentials or `accounts.txt` entries.
 2. Re-initialize sessions:
    ```bash
-   docker-compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py setup
+   docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py setup
    ```
 3. Restart the bot:
    ```bash
@@ -150,7 +150,7 @@ To develop with Docker:
 
 3. Use Docker Compose override:
    ```bash
-   docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
    ```
 
 ## Security Considerations


### PR DESCRIPTION
## Summary
- replace operational `docker-compose` calls with `docker compose` in the Makefile
- update Docker docs to match Compose v2 usage
- keep `docker-compose.yml` filename references intact

## Why
Docker Compose v1 hit a `ContainerConfig` recreate failure during deploy. The machine now has Compose v2 available and v1 removed, so project commands should use the supported plugin form.

## Validation
- `make -n dev dev-build build up down restart test-health accounts-status`
- `make test-health`
- `docker compose version` => v5.1.3
- confirmed `docker-compose` binary is absent
- bot container remains healthy