### PR TITLE
[codex] Tag hard account failures for replacement

### DIFF
--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -346,6 +346,7 @@ class AccountManager:
             "invalid username or password",
             "login_required",
             "login required",
+            "auth_failed",
             "unauthorized",
             "401",
             "rate_limited",

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -364,7 +364,7 @@ class AccountManager:
         if reason.startswith(LEGACY_HARD_FAILURE_PREFIX):
             legacy_reason = reason.removeprefix(LEGACY_HARD_FAILURE_PREFIX)
             return AccountManager._requires_replacement_for_failure_reason(legacy_reason)
-        return False
+        return AccountManager._requires_replacement_for_failure_reason(reason)
 
     @staticmethod
     def _requires_replacement_for_failure_reason(reason: str) -> bool:

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -12,6 +12,9 @@ from ..config.settings import settings
 
 logger = logging.getLogger(__name__)
 
+REPLACEMENT_REQUIRED_PREFIX = "replacement_required:"
+LEGACY_HARD_FAILURE_PREFIX = "hard_failure:"
+
 
 def _redact_proxy(proxy: Optional[str]) -> str:
     """Return proxy value with credentials removed for logs."""
@@ -351,6 +354,20 @@ class AccountManager:
         )
         return any(token in text for token in hard_tokens)
 
+    @staticmethod
+    def _is_replacement_required_ban_reason(reason: Optional[str]) -> bool:
+        """Return true for accounts that should stay out of rotation until replaced."""
+        if not reason:
+            return False
+        return reason.startswith(REPLACEMENT_REQUIRED_PREFIX) or reason.startswith(
+            LEGACY_HARD_FAILURE_PREFIX
+        )
+
+    @staticmethod
+    def _replacement_required_reason(reason: str) -> str:
+        """Build the persistent ban tag for accounts that should be replaced."""
+        return f"{REPLACEMENT_REQUIRED_PREFIX}{reason}"
+
     def record_account_failure(self, account: Account, reason: str) -> AccountHealthEvent:
         """Persist a sequential failure and quarantine accounts at threshold."""
         with self._lock:
@@ -371,7 +388,9 @@ class AccountManager:
             if threshold_reached:
                 account.is_banned = True
                 account.ban_reason = (
-                    f"hard_failure:{reason}" if hard_failure else f"sequential_failures:{reason}"
+                    self._replacement_required_reason(reason)
+                    if hard_failure
+                    else f"sequential_failures:{reason}"
                 )
                 account.banned_at = now
                 self._leased_accounts.discard(account.username)
@@ -547,6 +566,13 @@ class AccountManager:
 
             for account in self.accounts:
                 if account.is_banned and account.banned_at and account.banned_at < cutoff_time:
+                    if self._is_replacement_required_ban_reason(account.ban_reason):
+                        logger.info(
+                            "Keeping account %s unavailable; replacement required for: %s",
+                            account.username,
+                            account.ban_reason,
+                        )
+                        continue
                     logger.info(f"Resetting account {account.username} (banned {hours}+ hours ago for: {account.ban_reason})")
                     account.is_banned = False
                     account.ban_reason = None

--- a/src/instagram_video_bot/utils/account_manager.py
+++ b/src/instagram_video_bot/utils/account_manager.py
@@ -359,14 +359,35 @@ class AccountManager:
         """Return true for accounts that should stay out of rotation until replaced."""
         if not reason:
             return False
-        return reason.startswith(REPLACEMENT_REQUIRED_PREFIX) or reason.startswith(
-            LEGACY_HARD_FAILURE_PREFIX
+        if reason.startswith(REPLACEMENT_REQUIRED_PREFIX):
+            return True
+        if reason.startswith(LEGACY_HARD_FAILURE_PREFIX):
+            legacy_reason = reason.removeprefix(LEGACY_HARD_FAILURE_PREFIX)
+            return AccountManager._requires_replacement_for_failure_reason(legacy_reason)
+        return False
+
+    @staticmethod
+    def _requires_replacement_for_failure_reason(reason: str) -> bool:
+        """Return true when a hard failure indicates the account should be replaced."""
+        text = reason.lower()
+        temporary_hard_tokens = (
+            "rate_limited",
+            "rate limit",
+            "please wait",
         )
+        if any(token in text for token in temporary_hard_tokens):
+            return False
+        return AccountManager._is_hard_account_failure_reason(reason)
 
     @staticmethod
     def _replacement_required_reason(reason: str) -> str:
         """Build the persistent ban tag for accounts that should be replaced."""
         return f"{REPLACEMENT_REQUIRED_PREFIX}{reason}"
+
+    @staticmethod
+    def _temporary_hard_failure_reason(reason: str) -> str:
+        """Build the resettable hard-failure tag for temporary account cooldowns."""
+        return f"{LEGACY_HARD_FAILURE_PREFIX}{reason}"
 
     def record_account_failure(self, account: Account, reason: str) -> AccountHealthEvent:
         """Persist a sequential failure and quarantine accounts at threshold."""
@@ -387,11 +408,14 @@ class AccountManager:
             )
             if threshold_reached:
                 account.is_banned = True
-                account.ban_reason = (
-                    self._replacement_required_reason(reason)
-                    if hard_failure
-                    else f"sequential_failures:{reason}"
-                )
+                if hard_failure:
+                    account.ban_reason = (
+                        self._replacement_required_reason(reason)
+                        if self._requires_replacement_for_failure_reason(reason)
+                        else self._temporary_hard_failure_reason(reason)
+                    )
+                else:
+                    account.ban_reason = f"sequential_failures:{reason}"
                 account.banned_at = now
                 self._leased_accounts.discard(account.username)
 

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -232,6 +232,36 @@ def test_legacy_hard_failure_reset_only_for_temporary_reasons(monkeypatch, tmp_p
     assert [acc.username for acc in manager.get_available_accounts()] == ["limited"]
 
 
+def test_raw_setup_failure_reset_only_for_temporary_reasons(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "challenge", "limited")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    challenge_account = manager.accounts[0]
+    limited_account = manager.accounts[1]
+    old_ban_time = account_manager_module.datetime.now() - timedelta(hours=7)
+    for account, reason in (
+        (challenge_account, "challenge_required"),
+        (limited_account, "rate_limited"),
+    ):
+        account.is_banned = True
+        account.ban_reason = reason
+        account.banned_at = old_ban_time
+        account.consecutive_failures = 1
+        account.last_failure_reason = reason
+        account.last_failure_at = old_ban_time
+    manager._save_state()
+
+    manager.reset_old_banned_accounts(hours=6)
+
+    assert challenge_account.is_banned is True
+    assert challenge_account.ban_reason == "challenge_required"
+    assert limited_account.is_banned is False
+    assert limited_account.ban_reason is None
+    assert [acc.username for acc in manager.get_available_accounts()] == ["limited"]
+
+
 def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 2)

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -236,13 +236,15 @@ def test_raw_setup_failure_reset_only_for_temporary_reasons(monkeypatch, tmp_pat
     monkeypatch.chdir(tmp_path)
     accounts_file = tmp_path / "accounts.txt"
     state_file = tmp_path / "accounts_state.json"
-    _write_accounts(accounts_file, "challenge", "limited")
+    _write_accounts(accounts_file, "challenge", "auth", "limited")
     manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
     challenge_account = manager.accounts[0]
-    limited_account = manager.accounts[1]
+    auth_account = manager.accounts[1]
+    limited_account = manager.accounts[2]
     old_ban_time = account_manager_module.datetime.now() - timedelta(hours=7)
     for account, reason in (
         (challenge_account, "challenge_required"),
+        (auth_account, "auth_failed"),
         (limited_account, "rate_limited"),
     ):
         account.is_banned = True
@@ -257,6 +259,8 @@ def test_raw_setup_failure_reset_only_for_temporary_reasons(monkeypatch, tmp_pat
 
     assert challenge_account.is_banned is True
     assert challenge_account.ban_reason == "challenge_required"
+    assert auth_account.is_banned is True
+    assert auth_account.ban_reason == "auth_failed"
     assert limited_account.is_banned is False
     assert limited_account.ban_reason is None
     assert [acc.username for acc in manager.get_available_accounts()] == ["limited"]

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -88,13 +88,13 @@ def test_hard_account_failure_quarantines_immediately(monkeypatch, tmp_path: Pat
     assert event.threshold == 1
     assert event.threshold_reached is True
     assert account.is_banned is True
-    assert account.ban_reason == "hard_failure:manual_verification"
+    assert account.ban_reason == "replacement_required:manual_verification"
     assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
 
     state = json.loads(state_file.read_text())
     saved_account = next(acc for acc in state["accounts"] if acc["username"] == "first")
     assert saved_account["is_banned"] is True
-    assert saved_account["ban_reason"] == "hard_failure:manual_verification"
+    assert saved_account["ban_reason"] == "replacement_required:manual_verification"
 
 
 def test_hard_account_failure_quarantines_after_prior_soft_failure(monkeypatch, tmp_path: Path):
@@ -118,7 +118,7 @@ def test_hard_account_failure_quarantines_after_prior_soft_failure(monkeypatch, 
     assert hard_event.threshold == 1
     assert hard_event.threshold_reached is True
     assert account.is_banned is True
-    assert account.ban_reason == "hard_failure:manual_verification"
+    assert account.ban_reason == "replacement_required:manual_verification"
     assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
 
 
@@ -139,7 +139,38 @@ def test_failure_after_hard_quarantine_preserves_original_ban(monkeypatch, tmp_p
     assert repeated_event.consecutive_failures == 2
     assert repeated_event.threshold_reached is False
     assert account.is_banned is True
-    assert account.ban_reason == "hard_failure:manual_verification"
+    assert account.ban_reason == "replacement_required:manual_verification"
+    assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+
+def test_old_replacement_required_accounts_are_not_reset(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    replace_account = manager.accounts[0]
+    temporary_account = manager.accounts[1]
+    old_ban_time = account_manager_module.datetime.now() - timedelta(hours=7)
+    for account, reason in (
+        (replace_account, "replacement_required:manual_verification"),
+        (temporary_account, "provider_timeout_stale"),
+    ):
+        account.is_banned = True
+        account.ban_reason = reason
+        account.banned_at = old_ban_time
+        account.consecutive_failures = 1
+        account.last_failure_reason = reason.split(":", 1)[-1]
+        account.last_failure_at = old_ban_time
+    manager._save_state()
+
+    manager.reset_old_banned_accounts(hours=6)
+
+    assert replace_account.is_banned is True
+    assert replace_account.ban_reason == "replacement_required:manual_verification"
+    assert replace_account.consecutive_failures == 1
+    assert temporary_account.is_banned is False
+    assert temporary_account.ban_reason is None
     assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
 
 

--- a/tests/test_account_manager.py
+++ b/tests/test_account_manager.py
@@ -97,6 +97,34 @@ def test_hard_account_failure_quarantines_immediately(monkeypatch, tmp_path: Pat
     assert saved_account["ban_reason"] == "replacement_required:manual_verification"
 
 
+def test_rate_limit_failure_quarantines_temporarily(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 3)
+    monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_LOW_WATERMARK", 0)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "first", "second")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    account = manager.accounts[0]
+
+    event = manager.record_account_failure(account, "rate_limited")
+
+    assert event.consecutive_failures == 1
+    assert event.threshold == 1
+    assert event.threshold_reached is True
+    assert account.is_banned is True
+    assert account.ban_reason == "hard_failure:rate_limited"
+    assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+    account.banned_at = account_manager_module.datetime.now() - timedelta(hours=7)
+    manager.reset_old_banned_accounts(hours=6)
+
+    assert account.is_banned is False
+    assert account.ban_reason is None
+    assert account.consecutive_failures == 0
+    assert [acc.username for acc in manager.get_available_accounts()] == ["first", "second"]
+
+
 def test_hard_account_failure_quarantines_after_prior_soft_failure(monkeypatch, tmp_path: Path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(account_manager_module.settings, "ACCOUNT_FAILURE_THRESHOLD", 3)
@@ -172,6 +200,36 @@ def test_old_replacement_required_accounts_are_not_reset(monkeypatch, tmp_path: 
     assert temporary_account.is_banned is False
     assert temporary_account.ban_reason is None
     assert [acc.username for acc in manager.get_available_accounts()] == ["second"]
+
+
+def test_legacy_hard_failure_reset_only_for_temporary_reasons(monkeypatch, tmp_path: Path):
+    monkeypatch.chdir(tmp_path)
+    accounts_file = tmp_path / "accounts.txt"
+    state_file = tmp_path / "accounts_state.json"
+    _write_accounts(accounts_file, "manual", "limited")
+    manager = AccountManager(accounts_file=accounts_file, state_file=state_file)
+    manual_account = manager.accounts[0]
+    limited_account = manager.accounts[1]
+    old_ban_time = account_manager_module.datetime.now() - timedelta(hours=7)
+    for account, reason in (
+        (manual_account, "hard_failure:manual_verification"),
+        (limited_account, "hard_failure:rate_limited"),
+    ):
+        account.is_banned = True
+        account.ban_reason = reason
+        account.banned_at = old_ban_time
+        account.consecutive_failures = 1
+        account.last_failure_reason = reason.split(":", 1)[-1]
+        account.last_failure_at = old_ban_time
+    manager._save_state()
+
+    manager.reset_old_banned_accounts(hours=6)
+
+    assert manual_account.is_banned is True
+    assert manual_account.ban_reason == "hard_failure:manual_verification"
+    assert limited_account.is_banned is False
+    assert limited_account.ban_reason is None
+    assert [acc.username for acc in manager.get_available_accounts()] == ["limited"]
 
 
 def test_account_success_resets_failure_counter(monkeypatch, tmp_path: Path):

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -77,6 +77,7 @@ class _FakeUpdate:
         self.callback_query = callback_query
         self.pre_checkout_query = pre_checkout_query
         self.message = message
+        self.effective_message = message
         self.effective_chat = getattr(message, "chat", SimpleNamespace(id=1, type="private")) if message else None
         self.effective_user = SimpleNamespace(id=user_id, username="alice", full_name="Alice")
 


### PR DESCRIPTION
## Summary
- tag replacement-grade Instagram account failures as `replacement_required:<reason>` instead of temporary `hard_failure:<reason>`
- keep replacement-required accounts out of the 6-hour banned-account reset path
- keep rate-limit/`please wait` hard quarantines resettable as `hard_failure:<reason>` so transient cooldowns do not permanently drain the account pool
- preserve legacy `hard_failure:*` state by treating old auth/checkpoint failures as replacement-required while allowing old rate-limit failures to reset
- classify raw setup-time ban reasons too, so `challenge_required` stays replacement-quarantined while raw `rate_limited` remains resettable
- add account-manager coverage for replacement tags, reset behavior, temporary rate-limit quarantines, and raw setup-time challenge/rate-limit reasons
- fix the inline test fake update helper to expose `effective_message`, matching python-telegram-bot's `Update` API used by `handle_message`

## Why
Instagram manual verification, checkpoint, invalid credential, and login-required failures were being recycled after the old-ban reset window. That brought bad accounts back into rotation and hit the same Instagram blocks again.

The initial PR CI also exposed two existing inline tests whose fake `Update` object had `message` but not `effective_message`; the production handler reads `effective_message`.

Codex review identified that rate-limit failures should remain temporary. cubic found that setup-time raw `challenge_required` reasons also needed the replacement guard. This PR now separates immediate hard quarantine from replacement-required state across prefixed, legacy, and raw ban reasons.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_account_manager.py -q` -> 17 passed
- `STATE_DB_PATH=/tmp/pr34-ci-state-focused.sqlite3 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_telegram_bot_true_inline.py::test_owner_can_whitelist_forwarded_visible_user tests/test_telegram_bot_true_inline.py::test_owner_can_whitelist_forwarded_non_text_visible_user` -> 2 passed
- `STATE_DB_PATH=/tmp/pr34-ci-state.sqlite3 UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests` -> 307 passed