### PR TITLE
[codex] Fix inline forwarded whitelist and auth export permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,9 @@ accounts-reset-old: ## Reset accounts banned longer than HOURS hours (default 24
 	docker compose run --rm --entrypoint uv instagram-video-bot run --no-sync python /app/manage_accounts.py reset-old --hours $(if $(HOURS),$(HOURS),24)
 
 accounts-export-auth: ## Export fast fallback cookies from configured Instagram accounts
-	uv run --frozen python manage_accounts.py export-auth
+	@mkdir -p secrets
+	@test -f secrets/instagram_auth.json || printf '%s\n' '{"instagram":[],"instagram_bearer":[]}' > secrets/instagram_auth.json
+	docker compose run --rm --user root --entrypoint sh -v ./secrets:/app/secrets instagram-video-bot -c 'uv run --no-sync python /app/manage_accounts.py export-auth; status=$$?; chown -R 1000:1000 /app/sessions /app/secrets/instagram_auth.json 2>/dev/null || true; exit $$status'
 
 # Session Management Commands
 sessions-clean: ## Clean all session files (forces fresh login for all accounts)

--- a/src/instagram_video_bot/services/chaos_text.py
+++ b/src/instagram_video_bot/services/chaos_text.py
@@ -468,10 +468,6 @@ class ChaosText:
         return f"Inline whitelist: removed user {user_id}."
 
     @staticmethod
-    def inline_whitelist_forward_added(user_id: int) -> str:
-        return f"Inline whitelist: added forwarded user {user_id}."
-
-    @staticmethod
     def inline_whitelist_list(users: list[dict[str, Any]]) -> str:
         if not users:
             return "Inline whitelist is empty."

--- a/src/instagram_video_bot/services/telegram/request_intake.py
+++ b/src/instagram_video_bot/services/telegram/request_intake.py
@@ -49,10 +49,6 @@ class TelegramRequestIntake:
             limit=settings.MAX_LINKS_PER_MESSAGE,
         )
         if not extracted_links:
-            if bot._message_is_from_owner(
-                update
-            ) and await bot._whitelist_forwarded_visible_user(update):
-                return
             return
 
         group_settings = bot.state_store.ensure_group_settings(update.effective_chat.id)
@@ -115,4 +111,3 @@ class TelegramRequestIntake:
             task.add_done_callback(
                 lambda _task, rid=submission.request_id: bot._cleanup_request_task(rid)
             )
-

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -41,8 +41,7 @@ from .telegram_provider_metrics import record_provider_metrics
 from .telegram_status import (build_error_message, build_submission_message,
                               delete_status_message, edit_status_message,
                               safe_edit_text)
-from .telegram_update_helpers import (forwarded_visible_user_id,
-                                      language_from_profile,
+from .telegram_update_helpers import (language_from_profile,
                                       parse_positive_int_arg, parse_toggle_arg,
                                       request_user_id, request_user_label,
                                       user_label)
@@ -1592,33 +1591,6 @@ class TelegramBot:
     @staticmethod
     def _language_from_profile(language_code: str | None) -> str:
         return language_from_profile(language_code)
-
-    def _message_is_from_owner(self, update: Update) -> bool:
-        return (
-            settings.BOT_OWNER_USER_ID is not None
-            and update.effective_user is not None
-            and update.effective_user.id == settings.BOT_OWNER_USER_ID
-        )
-
-    async def _whitelist_forwarded_visible_user(self, update: Update) -> bool:
-        if not update.message or not update.effective_user:
-            return False
-        forwarded_user_id = self._forwarded_visible_user_id(update.message)
-        if forwarded_user_id is None:
-            return False
-        self.state_store.add_inline_whitelist_user(
-            forwarded_user_id,
-            added_by_user_id=update.effective_user.id,
-            note="owner_forward",
-        )
-        await update.message.reply_text(
-            ChaosText.inline_whitelist_forward_added(forwarded_user_id)
-        )
-        return True
-
-    @staticmethod
-    def _forwarded_visible_user_id(message: Message) -> int | None:
-        return forwarded_visible_user_id(message)
 
     async def _toggle_group_setting(
         self,

--- a/src/instagram_video_bot/services/telegram_update_helpers.py
+++ b/src/instagram_video_bot/services/telegram_update_helpers.py
@@ -58,19 +58,6 @@ def language_from_profile(language_code: str | None) -> str:
     return "en"
 
 
-def forwarded_visible_user_id(message: Any) -> int | None:
-    """Return a visible forwarded user ID from old or new Telegram message shapes."""
-
-    forward_from = getattr(message, "forward_from", None)
-    if getattr(forward_from, "id", None) is not None:
-        return int(forward_from.id)
-    forward_origin = getattr(message, "forward_origin", None)
-    sender_user = getattr(forward_origin, "sender_user", None)
-    if getattr(sender_user, "id", None) is not None:
-        return int(sender_user.id)
-    return None
-
-
 def parse_toggle_arg(value: str) -> bool | None:
     """Parse the on/off command tokens supported by group-setting commands."""
 

--- a/src/instagram_video_bot/utils/instagram_auth_exporter.py
+++ b/src/instagram_video_bot/utils/instagram_auth_exporter.py
@@ -202,25 +202,41 @@ def _write_auth_payload(path: Path, payload: Mapping[str, Any]) -> None:
     )
     os.chmod(temporary_path, 0o600)
     temporary_path.replace(path)
-    if _chown_for_container_bot_user(path):
-        os.chmod(path, 0o600)
-    else:
-        # Docker Compose local secrets ignore configured uid/gid/mode and project
-        # the source file permissions. Keep the file readable by the bot user
-        # when ownership cannot be adjusted on the host filesystem.
-        os.chmod(path, 0o644)
+    os.chmod(path, _container_bot_read_mode(path))
 
 
-def _chown_for_container_bot_user(path: Path) -> bool:
-    if not hasattr(os, "geteuid") or os.geteuid() != 0:
-        return False
+def _container_bot_read_mode(path: Path) -> int:
+    if path.stat().st_uid == CONTAINER_BOT_UID:
+        return 0o600
+    if path.stat().st_gid == CONTAINER_BOT_GID:
+        return 0o640
+    if not hasattr(os, "geteuid"):
+        return 0o600
+    effective_uid = os.geteuid()
+    if effective_uid == CONTAINER_BOT_UID:
+        return 0o600
+    if effective_uid != 0:
+        raise RuntimeError(
+            "Instagram auth export is owned by UID "
+            f"{effective_uid}, but the bot container reads secrets as UID "
+            f"{CONTAINER_BOT_UID}. Run export as root or UID "
+            f"{CONTAINER_BOT_UID}, or adjust the file owner/group manually."
+        )
     try:
         os.chown(path, CONTAINER_BOT_UID, CONTAINER_BOT_GID)
-        return True
+        return 0o600
     except OSError as exc:
         logger.warning(
-            "Could not change auth export owner for container readability; "
-            "falling back to owner-independent read mode (%s)",
+            "Could not change auth export owner for container readability (%s)",
             type(exc).__name__,
         )
-        return False
+    try:
+        os.chown(path, -1, CONTAINER_BOT_GID)
+        return 0o640
+    except OSError as exc:
+        logger.warning(
+            "Could not change auth export group for container readability; "
+            "leaving owner-only permissions (%s)",
+            type(exc).__name__,
+        )
+        return 0o600

--- a/src/instagram_video_bot/utils/instagram_auth_exporter.py
+++ b/src/instagram_video_bot/utils/instagram_auth_exporter.py
@@ -202,17 +202,25 @@ def _write_auth_payload(path: Path, payload: Mapping[str, Any]) -> None:
     )
     os.chmod(temporary_path, 0o600)
     temporary_path.replace(path)
-    _chown_for_container_bot_user(path)
-    os.chmod(path, 0o600)
+    if _chown_for_container_bot_user(path):
+        os.chmod(path, 0o600)
+    else:
+        # Docker Compose local secrets ignore configured uid/gid/mode and project
+        # the source file permissions. Keep the file readable by the bot user
+        # when ownership cannot be adjusted on the host filesystem.
+        os.chmod(path, 0o644)
 
 
-def _chown_for_container_bot_user(path: Path) -> None:
+def _chown_for_container_bot_user(path: Path) -> bool:
     if not hasattr(os, "geteuid") or os.geteuid() != 0:
-        return
+        return False
     try:
         os.chown(path, CONTAINER_BOT_UID, CONTAINER_BOT_GID)
+        return True
     except OSError as exc:
         logger.warning(
-            "Could not change auth export owner for container readability (%s)",
+            "Could not change auth export owner for container readability; "
+            "falling back to owner-independent read mode (%s)",
             type(exc).__name__,
         )
+        return False

--- a/tests/test_instagram_auth_exporter.py
+++ b/tests/test_instagram_auth_exporter.py
@@ -129,6 +129,43 @@ def test_export_instagram_auth_file_logs_in_accounts_and_preserves_bearers(
     assert chown_calls == [(output_path, 1000, 1000)]
 
 
+def test_export_instagram_auth_file_falls_back_to_readable_mode_when_chown_fails(
+    monkeypatch, tmp_path
+):
+    output_path = tmp_path / "secrets" / "instagram_auth.json"
+    monkeypatch.setattr(exporter_module.os, "geteuid", lambda: 0)
+
+    def fail_chown(_path, _uid, _gid):
+        raise OSError("unsupported ownership")
+
+    monkeypatch.setattr(exporter_module.os, "chown", fail_chown)
+
+    class FakeInnerClient:
+        def get_settings(self):
+            return {"cookies": {"sessionid": "session-first"}}
+
+    class FakeInstagramClient:
+        def __init__(self, **_kwargs):
+            self.client = FakeInnerClient()
+
+        def login(self):
+            return True
+
+    summary = export_instagram_auth_file(
+        [_account("first", tmp_path)],
+        output_path,
+        client_factory=FakeInstagramClient,
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "instagram": ["sessionid=session-first"],
+        "instagram_bearer": [],
+    }
+    assert summary.exported == 1
+    assert output_path.stat().st_mode & 0o777 == 0o644
+
+
 def test_export_instagram_auth_file_redacts_login_failures(tmp_path, caplog):
     output_path = tmp_path / "secrets" / "instagram_auth.json"
 

--- a/tests/test_instagram_auth_exporter.py
+++ b/tests/test_instagram_auth_exporter.py
@@ -3,6 +3,8 @@ import logging
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from src.instagram_video_bot.utils import instagram_auth_exporter as exporter_module
 from src.instagram_video_bot.utils.instagram_auth_exporter import (
     export_instagram_auth_file,
@@ -129,7 +131,85 @@ def test_export_instagram_auth_file_logs_in_accounts_and_preserves_bearers(
     assert chown_calls == [(output_path, 1000, 1000)]
 
 
-def test_export_instagram_auth_file_falls_back_to_readable_mode_when_chown_fails(
+def test_export_instagram_auth_file_falls_back_to_group_readable_mode_when_owner_chown_fails(
+    monkeypatch, tmp_path
+):
+    output_path = tmp_path / "secrets" / "instagram_auth.json"
+    monkeypatch.setattr(exporter_module.os, "geteuid", lambda: 0)
+    chown_calls = []
+
+    def chown_group_only(path, uid, gid):
+        chown_calls.append((path, uid, gid))
+        if uid == 1000:
+            raise OSError("unsupported ownership")
+
+    monkeypatch.setattr(exporter_module.os, "chown", chown_group_only)
+
+    class FakeInnerClient:
+        def get_settings(self):
+            return {"cookies": {"sessionid": "session-first"}}
+
+    class FakeInstagramClient:
+        def __init__(self, **_kwargs):
+            self.client = FakeInnerClient()
+
+        def login(self):
+            return True
+
+    summary = export_instagram_auth_file(
+        [_account("first", tmp_path)],
+        output_path,
+        client_factory=FakeInstagramClient,
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "instagram": ["sessionid=session-first"],
+        "instagram_bearer": [],
+    }
+    assert summary.exported == 1
+    assert output_path.stat().st_mode & 0o777 == 0o640
+    assert chown_calls == [(output_path, 1000, 1000), (output_path, -1, 1000)]
+
+
+def test_export_instagram_auth_file_keeps_private_mode_for_bot_uid(
+    monkeypatch, tmp_path
+):
+    output_path = tmp_path / "secrets" / "instagram_auth.json"
+    monkeypatch.setattr(exporter_module.os, "geteuid", lambda: 1000)
+
+    def fail_if_chown_called(_path, _uid, _gid):
+        raise AssertionError("non-root bot uid export should not chown")
+
+    monkeypatch.setattr(exporter_module.os, "chown", fail_if_chown_called)
+
+    class FakeInnerClient:
+        def get_settings(self):
+            return {"cookies": {"sessionid": "session-first"}}
+
+    class FakeInstagramClient:
+        def __init__(self, **_kwargs):
+            self.client = FakeInnerClient()
+
+        def login(self):
+            return True
+
+    summary = export_instagram_auth_file(
+        [_account("first", tmp_path)],
+        output_path,
+        client_factory=FakeInstagramClient,
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "instagram": ["sessionid=session-first"],
+        "instagram_bearer": [],
+    }
+    assert summary.exported == 1
+    assert output_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_export_instagram_auth_file_keeps_private_mode_when_chown_fallbacks_fail(
     monkeypatch, tmp_path
 ):
     output_path = tmp_path / "secrets" / "instagram_auth.json"
@@ -163,11 +243,39 @@ def test_export_instagram_auth_file_falls_back_to_readable_mode_when_chown_fails
         "instagram_bearer": [],
     }
     assert summary.exported == 1
-    assert output_path.stat().st_mode & 0o777 == 0o644
+    assert output_path.stat().st_mode & 0o777 == 0o600
 
 
-def test_export_instagram_auth_file_redacts_login_failures(tmp_path, caplog):
+def test_export_instagram_auth_file_fails_for_non_bot_non_root_uid(
+    monkeypatch, tmp_path
+):
     output_path = tmp_path / "secrets" / "instagram_auth.json"
+    monkeypatch.setattr(exporter_module.os, "geteuid", lambda: 501)
+
+    class FakeInnerClient:
+        def get_settings(self):
+            return {"cookies": {"sessionid": "session-first"}}
+
+    class FakeInstagramClient:
+        def __init__(self, **_kwargs):
+            self.client = FakeInnerClient()
+
+        def login(self):
+            return True
+
+    with pytest.raises(RuntimeError, match="bot container reads secrets as UID 1000"):
+        export_instagram_auth_file(
+            [_account("first", tmp_path)],
+            output_path,
+            client_factory=FakeInstagramClient,
+        )
+
+    assert output_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_export_instagram_auth_file_redacts_login_failures(monkeypatch, tmp_path, caplog):
+    output_path = tmp_path / "secrets" / "instagram_auth.json"
+    monkeypatch.setattr(exporter_module.os, "geteuid", lambda: 1000)
 
     class FailingInstagramClient:
         def __init__(self, **_kwargs):

--- a/tests/test_makefile_accounts_export_auth.py
+++ b/tests/test_makefile_accounts_export_auth.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_accounts_export_auth_runs_containerized_exporter() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    _, target = makefile.split("accounts-export-auth:", maxsplit=1)
+    recipe = target.split("\n\n", maxsplit=1)[0]
+
+    assert "uv run --frozen python manage_accounts.py export-auth" not in recipe
+    assert "docker compose run" in recipe
+    assert "--user root" in recipe
+    assert "-v ./secrets:/app/secrets" in recipe
+    assert "python /app/manage_accounts.py export-auth" in recipe
+    assert "chown -R 1000:1000 /app/sessions /app/secrets/instagram_auth.json" in recipe

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -1011,7 +1011,7 @@ async def test_owner_can_whitelist_user_by_id(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_owner_can_whitelist_forwarded_visible_user(monkeypatch, tmp_path):
+async def test_owner_forwarded_visible_user_message_does_not_whitelist(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "BOT_OWNER_USER_ID", 42)
     store = StateStore(tmp_path / "state.db")
     bot = TelegramBot(state_store=store)
@@ -1023,11 +1023,12 @@ async def test_owner_can_whitelist_forwarded_visible_user(monkeypatch, tmp_path)
         SimpleNamespace(bot=SimpleNamespace()),
     )
 
-    assert bot.state_store.is_inline_whitelisted(1001) is True
+    assert bot.state_store.is_inline_whitelisted(1001) is False
+    assert message.replies == []
 
 
 @pytest.mark.asyncio
-async def test_owner_can_whitelist_forwarded_non_text_visible_user(monkeypatch, tmp_path):
+async def test_owner_forwarded_visible_user_media_does_not_whitelist(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "BOT_OWNER_USER_ID", 42)
     store = StateStore(tmp_path / "state.db")
     bot = TelegramBot(state_store=store)
@@ -1039,7 +1040,8 @@ async def test_owner_can_whitelist_forwarded_non_text_visible_user(monkeypatch, 
         SimpleNamespace(bot=SimpleNamespace()),
     )
 
-    assert bot.state_store.is_inline_whitelisted(1001) is True
+    assert bot.state_store.is_inline_whitelisted(1001) is False
+    assert message.replies == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_update_helpers.py
+++ b/tests/test_telegram_update_helpers.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 
 from src.instagram_video_bot.services.telegram_update_helpers import (
-    forwarded_visible_user_id, language_from_profile, parse_positive_int_arg,
-    parse_toggle_arg, request_user_id, request_user_label)
+    language_from_profile, parse_positive_int_arg, parse_toggle_arg,
+    request_user_id, request_user_label)
 
 
 def _update(*, user=None, message=None):
@@ -40,17 +40,6 @@ def test_language_from_profile_maps_russian_variants_to_ru():
     assert language_from_profile("ru-RU") == "ru"
     assert language_from_profile("en-US") == "en"
     assert language_from_profile(None) == "en"
-
-
-def test_forwarded_visible_user_id_supports_old_and_new_telegram_shapes():
-    legacy_message = SimpleNamespace(forward_from=SimpleNamespace(id=1001))
-    origin_message = SimpleNamespace(
-        forward_from=None,
-        forward_origin=SimpleNamespace(sender_user=SimpleNamespace(id=1002)),
-    )
-
-    assert forwarded_visible_user_id(legacy_message) == 1001
-    assert forwarded_visible_user_id(origin_message) == 1002
 
 
 def test_parse_toggle_arg_and_positive_int_arg():


### PR DESCRIPTION
## Summary
- Stop passive forwarded messages from granting true-inline whitelist access.
- Keep inline whitelist grants on the explicit /inline_whitelist add <user_id> command path.
- Preserve the auth exporter fix that falls back to bot-readable permissions when host chown fails for Compose local secrets.

## Why
- Admin-forwarded messages in a chat with the bot could accidentally whitelist the forwarded user for inline usage.
- Docker Compose local secrets can project source-file permissions, so a root-owned 0600 export can remain unreadable to the bot user when chown is unavailable.

## Test Plan
- git diff --check HEAD~2..HEAD
- UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q