### PR TITLE
Retry inline provider downloads

### DIFF
--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1175,15 +1175,15 @@ class TelegramBot:
     @staticmethod
     def _should_retry_inline_download(error: DownloadError) -> bool:
         text = str(error).lower()
-        permanent_tokens = (
-            "content_restricted",
-            "content isn't available to everyone",
-            "certain audiences",
-            "age-restricted",
-            "age restricted",
-            "unsupported",
+        transient_tokens = (
+            "timeout",
+            "timed out",
+            "temporary",
+            "temporarily",
+            "connection",
+            "network",
         )
-        return not any(token in text for token in permanent_tokens)
+        return any(token in text for token in transient_tokens)
 
     def _mark_inline_session_failed_and_record_access(
         self,

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1135,7 +1135,11 @@ class TelegramBot:
     async def _download_inline_video_with_retries(
         self, parsed_link: ParsedRequestLink, output_dir: Path
     ) -> VideoInfo:
-        attempts = max(1, settings.PROVIDER_TRANSIENT_RETRY_ATTEMPTS)
+        attempts = (
+            max(1, settings.PROVIDER_TRANSIENT_RETRY_ATTEMPTS)
+            if parsed_link.provider == "instagram"
+            else 1
+        )
         last_error: DownloadError | None = None
         for attempt in range(attempts):
             downloader = VideoDownloader()

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1175,6 +1175,8 @@ class TelegramBot:
 
     @staticmethod
     def _should_retry_inline_download(error: DownloadError) -> bool:
+        if isinstance(error, video_downloader_module.InstagramProviderTimeoutError):
+            return False
         return video_downloader_module.is_transient_download_error(error)
 
     def _mark_inline_session_failed_and_record_access(

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1066,8 +1066,8 @@ class TelegramBot:
                     ):
                         output_dir.mkdir(parents=True, exist_ok=True)
                         failure_stage = "download"
-                        video_info = await VideoDownloader().download_video(
-                            parsed_link.original_url, output_dir
+                        video_info = await self._download_inline_video_with_retries(
+                            parsed_link, output_dir
                         )
                         failure_stage = "storage_upload"
                         inline_item = await upload_first_media_to_storage(
@@ -1131,6 +1131,55 @@ class TelegramBot:
                 )
         finally:
             self._inline_delivery_session_tokens.discard(session_token)
+
+    async def _download_inline_video_with_retries(
+        self, parsed_link: ParsedRequestLink, output_dir: Path
+    ) -> VideoInfo:
+        attempts = max(1, settings.PROVIDER_TRANSIENT_RETRY_ATTEMPTS)
+        last_error: DownloadError | None = None
+        for attempt in range(attempts):
+            downloader = VideoDownloader()
+            try:
+                return await downloader.download_video(
+                    parsed_link.original_url, output_dir
+                )
+            except DownloadError as error:
+                last_error = error
+                if (
+                    attempt == attempts - 1
+                    or not self._should_retry_inline_download(error)
+                ):
+                    raise
+                logger.warning(
+                    "Retrying inline provider download after failure",
+                    extra={
+                        "provider": parsed_link.provider,
+                        "normalized_url": parsed_link.normalized_url,
+                        "attempt": attempt + 1,
+                        "attempts": attempts,
+                        "error_class": error.__class__.__name__,
+                    },
+                )
+                shutil.rmtree(output_dir, ignore_errors=True)
+                output_dir.mkdir(parents=True, exist_ok=True)
+                await asyncio.sleep(
+                    max(0.0, settings.PROVIDER_RETRY_BACKOFF_SECONDS) * (attempt + 1)
+                )
+        assert last_error is not None
+        raise last_error
+
+    @staticmethod
+    def _should_retry_inline_download(error: DownloadError) -> bool:
+        text = str(error).lower()
+        permanent_tokens = (
+            "content_restricted",
+            "content isn't available to everyone",
+            "certain audiences",
+            "age-restricted",
+            "age restricted",
+            "unsupported",
+        )
+        return not any(token in text for token in permanent_tokens)
 
     def _mark_inline_session_failed_and_record_access(
         self,

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -17,6 +17,7 @@ from telegram.error import NetworkError, TelegramError
 from telegram.ext import Application, ContextTypes
 
 from ..config.settings import settings
+from . import video_downloader as video_downloader_module
 from .chaos_text import ChaosText, TextContext
 from .inline_access import (build_inline_result_id,
                             build_one_time_entitlement_result_id,
@@ -1174,16 +1175,7 @@ class TelegramBot:
 
     @staticmethod
     def _should_retry_inline_download(error: DownloadError) -> bool:
-        text = str(error).lower()
-        transient_tokens = (
-            "timeout",
-            "timed out",
-            "temporary",
-            "temporarily",
-            "connection",
-            "network",
-        )
-        return any(token in text for token in transient_tokens)
+        return video_downloader_module.is_transient_download_error(error)
 
     def _mark_inline_session_failed_and_record_access(
         self,

--- a/src/instagram_video_bot/services/video_downloader.py
+++ b/src/instagram_video_bot/services/video_downloader.py
@@ -41,6 +41,21 @@ class InstagramProviderTimeoutError(DownloadError):
     """Raised when a blocking Instagram provider operation exceeds its budget."""
 
 
+def is_transient_download_error(error: Exception) -> bool:
+    text = str(error).lower()
+    return any(
+        token in text
+        for token in (
+            "timeout",
+            "timed out",
+            "temporary",
+            "temporarily",
+            "connection",
+            "network",
+        )
+    )
+
+
 class VideoDownloader:
     """Service for downloading Instagram videos using instagrapi."""
 
@@ -421,11 +436,7 @@ class VideoDownloader:
 
     @staticmethod
     def _is_transient_download_error(error: Exception) -> bool:
-        text = str(error).lower()
-        return any(
-            token in text
-            for token in ("timeout", "timed out", "temporary", "temporarily", "connection", "network")
-        )
+        return is_transient_download_error(error)
 
     @staticmethod
     def _classify_instagram_account_failure(error: Exception) -> str:

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -684,6 +684,37 @@ async def test_inline_delivery_retries_provider_download_failure(monkeypatch, tm
 
 
 @pytest.mark.asyncio
+async def test_inline_download_wrapper_does_not_retry_permanent_failure(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 3)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir))
+            raise DownloadError("No Instagram accounts available")
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+
+    with pytest.raises(DownloadError, match="No Instagram accounts available"):
+        await bot._download_inline_video_with_retries(
+            SimpleNamespace(
+                provider="instagram",
+                original_url="https://www.instagram.com/reel/abc/",
+                normalized_url="https://www.instagram.com/reel/abc/",
+            ),
+            tmp_path / "inline",
+        )
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
 async def test_inline_download_wrapper_does_not_retry_non_instagram_provider(
     monkeypatch, tmp_path
 ):

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -684,6 +684,37 @@ async def test_inline_delivery_retries_provider_download_failure(monkeypatch, tm
 
 
 @pytest.mark.asyncio
+async def test_inline_download_wrapper_does_not_retry_non_instagram_provider(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 3)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir))
+            raise DownloadError("temporary provider failure")
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+
+    with pytest.raises(DownloadError):
+        await bot._download_inline_video_with_retries(
+            SimpleNamespace(
+                provider="twitter",
+                original_url="https://x.com/example/status/123",
+                normalized_url="https://x.com/example/status/123",
+            ),
+            tmp_path / "inline",
+        )
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
 async def test_inline_delivery_caches_and_edits_video_portrait_metadata(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "INLINE_STORAGE_CHAT_ID", -100)
     monkeypatch.setattr(settings, "CACHE_DIR", tmp_path / "cache")

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -7,8 +7,15 @@ from telegram import InputInvoiceMessageContent
 from telegram.error import NetworkError, TelegramError
 
 from src.instagram_video_bot.config.settings import settings
-from src.instagram_video_bot.services.download_models import MediaItem, VideoInfo
-from src.instagram_video_bot.services.inline_access import build_one_time_payload, build_subscription_payload
+from src.instagram_video_bot.services.download_models import (
+    DownloadError,
+    MediaItem,
+    VideoInfo,
+)
+from src.instagram_video_bot.services.inline_access import (
+    build_one_time_payload,
+    build_subscription_payload,
+)
 from src.instagram_video_bot.services.inline_delivery import InlineCachedMediaItem
 from src.instagram_video_bot.services.state_store import StateStore
 from src.instagram_video_bot.services.telegram_bot import TelegramBot
@@ -573,7 +580,9 @@ async def test_inline_delivery_removes_download_files_after_storage_upload(monke
             )
 
     async def fake_upload(*args, **kwargs):
-        return InlineCachedMediaItem(media_type="video", file_id="video-file-id", caption="Caption")
+        return InlineCachedMediaItem(
+            media_type="video", file_id="video-file-id", caption="Caption"
+        )
 
     fake_telegram_bot = SimpleNamespace(edited_media=None)
 
@@ -581,8 +590,13 @@ async def test_inline_delivery_removes_download_files_after_storage_upload(monke
         fake_telegram_bot.edited_media = kwargs
 
     fake_telegram_bot.edit_message_media = edit_message_media
-    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader)
-    monkeypatch.setattr("src.instagram_video_bot.services.telegram_bot.upload_first_media_to_storage", fake_upload)
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.upload_first_media_to_storage",
+        fake_upload,
+    )
 
     await bot._deliver_inline_session(
         SimpleNamespace(bot=fake_telegram_bot),
@@ -593,6 +607,80 @@ async def test_inline_delivery_removes_download_files_after_storage_upload(monke
     assert store.get_inline_session("s1")["status"] == "delivered"
     assert fake_telegram_bot.edited_media["inline_message_id"] == "inline-msg"
     assert output_dir.exists() is False
+
+
+@pytest.mark.asyncio
+async def test_inline_delivery_retries_provider_download_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "INLINE_STORAGE_CHAT_ID", -100)
+    monkeypatch.setattr(settings, "CACHE_DIR", tmp_path / "cache")
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 2)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    store = StateStore(tmp_path / "state.db")
+    store.create_inline_session(
+        session_token="s1",
+        user_id=1001,
+        original_url="https://www.instagram.com/reel/abc/",
+        normalized_url="https://www.instagram.com/reel/abc/",
+        provider="instagram",
+        provider_label="Instagram",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+    )
+    store.attach_inline_message("s1", inline_message_id="inline-msg")
+    bot = TelegramBot(state_store=store)
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir.exists()))
+            if len(attempts) == 1:
+                partial_file = target_dir / "partial.mp4"
+                partial_file.write_bytes(b"partial")
+                raise DownloadError("temporary provider failure")
+            assert (target_dir / "partial.mp4").exists() is False
+            media_file = target_dir / "video.mp4"
+            media_file.write_bytes(b"video")
+            return VideoInfo(
+                file_path=media_file,
+                title="Title",
+                media_items=[
+                    MediaItem(
+                        file_path=media_file,
+                        media_type="video",
+                        caption="Caption",
+                    )
+                ],
+                primary_media_type="video",
+            )
+
+    async def fake_upload(*args, **kwargs):
+        return InlineCachedMediaItem(
+            media_type="video", file_id="video-file-id", caption="Caption"
+        )
+
+    fake_telegram_bot = SimpleNamespace(edited_media=None)
+
+    async def edit_message_media(**kwargs):
+        fake_telegram_bot.edited_media = kwargs
+
+    fake_telegram_bot.edit_message_media = edit_message_media
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.upload_first_media_to_storage",
+        fake_upload,
+    )
+
+    await bot._deliver_inline_session(
+        SimpleNamespace(bot=fake_telegram_bot),
+        session_token="s1",
+        one_time_payment_id=None,
+    )
+
+    session = store.get_inline_session("s1")
+    assert session["status"] == "delivered"
+    assert len(attempts) == 2
+    assert fake_telegram_bot.edited_media["inline_message_id"] == "inline-msg"
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -19,6 +19,7 @@ from src.instagram_video_bot.services.inline_access import (
 from src.instagram_video_bot.services.inline_delivery import InlineCachedMediaItem
 from src.instagram_video_bot.services.state_store import StateStore
 from src.instagram_video_bot.services.telegram_bot import TelegramBot
+from src.instagram_video_bot.services.video_downloader import InstagramProviderTimeoutError
 
 
 class _FakeInlineQuery:
@@ -702,6 +703,39 @@ async def test_inline_download_wrapper_does_not_retry_permanent_failure(
     )
 
     with pytest.raises(DownloadError, match="No Instagram accounts available"):
+        await bot._download_inline_video_with_retries(
+            SimpleNamespace(
+                provider="instagram",
+                original_url="https://www.instagram.com/reel/abc/",
+                normalized_url="https://www.instagram.com/reel/abc/",
+            ),
+            tmp_path / "inline",
+        )
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+async def test_inline_download_wrapper_does_not_retry_instagram_provider_timeout(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 3)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir))
+            raise InstagramProviderTimeoutError(
+                "Instagram provider timed out after 1 seconds"
+            )
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+
+    with pytest.raises(InstagramProviderTimeoutError, match="timed out"):
         await bot._download_inline_video_with_retries(
             SimpleNamespace(
                 provider="instagram",


### PR DESCRIPTION
## Summary
- retry inline provider downloads before marking inline sessions failed
- clear partial inline download files between retry attempts
- add regression coverage for first-attempt provider download failure followed by successful inline delivery

## Tests
- env PYTHONPYCACHEPREFIX=/tmp/pycache-inline-retry python -m compileall src/instagram_video_bot/services/telegram_bot.py tests/test_telegram_bot_true_inline.py
- env UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run pytest tests/test_telegram_bot_true_inline.py