### PR TITLE
Avoid retrying wrapped provider timeouts

### DIFF
--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1177,10 +1177,22 @@ class TelegramBot:
     def _should_retry_inline_download(error: DownloadError) -> bool:
         if isinstance(error, video_downloader_module.InstagramProviderTimeoutError):
             return False
-        error_text = str(error).lower()
-        if "instagram provider timed out" in error_text:
+        error_text = TelegramBot._primary_inline_download_error_text(error)
+        if (
+            error_text.startswith("instagram provider timed out")
+            or error_text.startswith("fast_path_error=instagram provider timed out")
+        ):
             return False
-        return video_downloader_module.is_transient_download_error(error)
+        return video_downloader_module.is_transient_download_error(
+            DownloadError(error_text)
+        )
+
+    @staticmethod
+    def _primary_inline_download_error_text(error: DownloadError) -> str:
+        error_text = str(error).lower()
+        if error_text.startswith("download failed:"):
+            error_text = error_text.removeprefix("download failed:").strip()
+        return error_text.split("(fast_path_error=", 1)[0].strip()
 
     def _mark_inline_session_failed_and_record_access(
         self,

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1177,7 +1177,14 @@ class TelegramBot:
     def _should_retry_inline_download(error: DownloadError) -> bool:
         if isinstance(error, video_downloader_module.InstagramProviderTimeoutError):
             return False
-        if "instagram provider timed out" in str(error).lower():
+        error_text = str(error).lower()
+        if (
+            error_text.startswith("instagram provider timed out")
+            or error_text.startswith("download failed: instagram provider timed out")
+            or error_text.startswith(
+                "download failed: fast_path_error=instagram provider timed out"
+            )
+        ):
             return False
         return video_downloader_module.is_transient_download_error(error)
 

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1177,6 +1177,8 @@ class TelegramBot:
     def _should_retry_inline_download(error: DownloadError) -> bool:
         if isinstance(error, video_downloader_module.InstagramProviderTimeoutError):
             return False
+        if "instagram provider timed out" in str(error).lower():
+            return False
         return video_downloader_module.is_transient_download_error(error)
 
     def _mark_inline_session_failed_and_record_access(

--- a/src/instagram_video_bot/services/telegram_bot.py
+++ b/src/instagram_video_bot/services/telegram_bot.py
@@ -1178,13 +1178,7 @@ class TelegramBot:
         if isinstance(error, video_downloader_module.InstagramProviderTimeoutError):
             return False
         error_text = str(error).lower()
-        if (
-            error_text.startswith("instagram provider timed out")
-            or error_text.startswith("download failed: instagram provider timed out")
-            or error_text.startswith(
-                "download failed: fast_path_error=instagram provider timed out"
-            )
-        ):
+        if "instagram provider timed out" in error_text:
             return False
         return video_downloader_module.is_transient_download_error(error)
 

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -783,7 +783,7 @@ async def test_inline_download_wrapper_does_not_retry_wrapped_provider_timeout(
 
 
 @pytest.mark.asyncio
-async def test_inline_download_wrapper_does_not_retry_transient_with_fast_timeout(
+async def test_inline_download_wrapper_retries_transient_failure_with_fast_timeout(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 2)
@@ -794,26 +794,41 @@ async def test_inline_download_wrapper_does_not_retry_transient_with_fast_timeou
     class FakeDownloader:
         async def download_video(self, original_url, target_dir):
             attempts.append((original_url, target_dir.exists()))
-            raise DownloadError(
-                "Download failed: temporary fallback network failure "
-                "(fast_path_error=Instagram provider timed out after 1 seconds)"
+            if len(attempts) == 1:
+                raise DownloadError(
+                    "Download failed: temporary fallback network failure "
+                    "(fast_path_error=Instagram provider timed out after 1 seconds)"
+                )
+            media_file = target_dir / "video.mp4"
+            media_file.write_bytes(b"video")
+            return VideoInfo(
+                file_path=media_file,
+                title="Title",
+                media_items=[
+                    MediaItem(
+                        file_path=media_file,
+                        media_type="video",
+                        caption="Caption",
+                    )
+                ],
+                primary_media_type="video",
             )
 
     monkeypatch.setattr(
         "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
     )
 
-    with pytest.raises(DownloadError, match="temporary fallback network failure"):
-        await bot._download_inline_video_with_retries(
-            SimpleNamespace(
-                provider="instagram",
-                original_url="https://www.instagram.com/reel/abc/",
-                normalized_url="https://www.instagram.com/reel/abc/",
-            ),
-            tmp_path / "inline",
-        )
+    video_info = await bot._download_inline_video_with_retries(
+        SimpleNamespace(
+            provider="instagram",
+            original_url="https://www.instagram.com/reel/abc/",
+            normalized_url="https://www.instagram.com/reel/abc/",
+        ),
+        tmp_path / "inline",
+    )
 
-    assert len(attempts) == 1
+    assert len(attempts) == 2
+    assert video_info.file_path.name == "video.mp4"
 
 
 @pytest.mark.asyncio

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -783,6 +783,55 @@ async def test_inline_download_wrapper_does_not_retry_wrapped_provider_timeout(
 
 
 @pytest.mark.asyncio
+async def test_inline_download_wrapper_retries_transient_failure_with_fast_timeout(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 2)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir.exists()))
+            if len(attempts) == 1:
+                raise DownloadError(
+                    "Download failed: temporary fallback network failure "
+                    "(fast_path_error=Instagram provider timed out after 1 seconds)"
+                )
+            media_file = target_dir / "video.mp4"
+            media_file.write_bytes(b"video")
+            return VideoInfo(
+                file_path=media_file,
+                title="Title",
+                media_items=[
+                    MediaItem(
+                        file_path=media_file,
+                        media_type="video",
+                        caption="Caption",
+                    )
+                ],
+                primary_media_type="video",
+            )
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+
+    video_info = await bot._download_inline_video_with_retries(
+        SimpleNamespace(
+            provider="instagram",
+            original_url="https://www.instagram.com/reel/abc/",
+            normalized_url="https://www.instagram.com/reel/abc/",
+        ),
+        tmp_path / "inline",
+    )
+
+    assert len(attempts) == 2
+    assert video_info.file_path.name == "video.mp4"
+
+
+@pytest.mark.asyncio
 async def test_inline_download_wrapper_does_not_retry_non_instagram_provider(
     monkeypatch, tmp_path
 ):

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -749,6 +749,40 @@ async def test_inline_download_wrapper_does_not_retry_instagram_provider_timeout
 
 
 @pytest.mark.asyncio
+async def test_inline_download_wrapper_does_not_retry_wrapped_provider_timeout(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 3)
+    monkeypatch.setattr(settings, "PROVIDER_RETRY_BACKOFF_SECONDS", 0)
+    bot = TelegramBot(state_store=StateStore(tmp_path / "state.db"))
+    attempts = []
+
+    class FakeDownloader:
+        async def download_video(self, original_url, target_dir):
+            attempts.append((original_url, target_dir))
+            raise DownloadError(
+                "Download failed: fast_path_error=Instagram provider timed out "
+                "after 1 seconds"
+            )
+
+    monkeypatch.setattr(
+        "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
+    )
+
+    with pytest.raises(DownloadError, match="Instagram provider timed out"):
+        await bot._download_inline_video_with_retries(
+            SimpleNamespace(
+                provider="instagram",
+                original_url="https://www.instagram.com/reel/abc/",
+                normalized_url="https://www.instagram.com/reel/abc/",
+            ),
+            tmp_path / "inline",
+        )
+
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
 async def test_inline_download_wrapper_does_not_retry_non_instagram_provider(
     monkeypatch, tmp_path
 ):

--- a/tests/test_telegram_bot_true_inline.py
+++ b/tests/test_telegram_bot_true_inline.py
@@ -783,7 +783,7 @@ async def test_inline_download_wrapper_does_not_retry_wrapped_provider_timeout(
 
 
 @pytest.mark.asyncio
-async def test_inline_download_wrapper_retries_transient_failure_with_fast_timeout(
+async def test_inline_download_wrapper_does_not_retry_transient_with_fast_timeout(
     monkeypatch, tmp_path
 ):
     monkeypatch.setattr(settings, "PROVIDER_TRANSIENT_RETRY_ATTEMPTS", 2)
@@ -794,41 +794,26 @@ async def test_inline_download_wrapper_retries_transient_failure_with_fast_timeo
     class FakeDownloader:
         async def download_video(self, original_url, target_dir):
             attempts.append((original_url, target_dir.exists()))
-            if len(attempts) == 1:
-                raise DownloadError(
-                    "Download failed: temporary fallback network failure "
-                    "(fast_path_error=Instagram provider timed out after 1 seconds)"
-                )
-            media_file = target_dir / "video.mp4"
-            media_file.write_bytes(b"video")
-            return VideoInfo(
-                file_path=media_file,
-                title="Title",
-                media_items=[
-                    MediaItem(
-                        file_path=media_file,
-                        media_type="video",
-                        caption="Caption",
-                    )
-                ],
-                primary_media_type="video",
+            raise DownloadError(
+                "Download failed: temporary fallback network failure "
+                "(fast_path_error=Instagram provider timed out after 1 seconds)"
             )
 
     monkeypatch.setattr(
         "src.instagram_video_bot.services.telegram_bot.VideoDownloader", FakeDownloader
     )
 
-    video_info = await bot._download_inline_video_with_retries(
-        SimpleNamespace(
-            provider="instagram",
-            original_url="https://www.instagram.com/reel/abc/",
-            normalized_url="https://www.instagram.com/reel/abc/",
-        ),
-        tmp_path / "inline",
-    )
+    with pytest.raises(DownloadError, match="temporary fallback network failure"):
+        await bot._download_inline_video_with_retries(
+            SimpleNamespace(
+                provider="instagram",
+                original_url="https://www.instagram.com/reel/abc/",
+                normalized_url="https://www.instagram.com/reel/abc/",
+            ),
+            tmp_path / "inline",
+        )
 
-    assert len(attempts) == 2
-    assert video_info.file_path.name == "video.mp4"
+    assert len(attempts) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Skip inline retry attempts when an Instagram provider timeout is wrapped inside a DownloadError message
- Add regression coverage for wrapped provider timeout failures

## Verification
- env UV_CACHE_DIR=/tmp/uv-cache UV_PYTHON_INSTALL_DIR=/tmp/uv-python uv run pytest tests/test_telegram_bot_true_inline.py::test_inline_download_wrapper_does_not_retry_wrapped_provider_timeout tests/test_telegram_bot_true_inline.py::test_inline_download_wrapper_does_not_retry_instagram_provider_timeout tests/test_telegram_bot_true_inline.py::test_inline_delivery_retries_provider_download_failure -q